### PR TITLE
Fix display unnecessary insert button and delete button on the navigation bar (WebKit only)

### DIFF
--- a/develop-im/INTER-Mediator/INTER-Mediator.js
+++ b/develop-im/INTER-Mediator/INTER-Mediator.js
@@ -2178,7 +2178,7 @@ var INTERMediator = {
                             this.value = max_page;
                         }
                         INTERMediator.startFrom = ( ~~this.value - 1 ) * pageSize;
-                        INTERMediator.constructMain(true);
+                        INTERMediator.construct(true);
                     }
                 )
                 // ---------

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -53,6 +53,9 @@ Change Log
 
 Latest changes might exist on the GitHub repository. Please check https://github.com/msyk/INTER-Mediator.
 
+Ver.3.9-dev
+- [BUG FIX] Fix display unnecessary insert button and delete button on the navigation bar after pressing an "enter" key in the text box of the moving page control on the navigation bar (WebKit browsers only).
+
 Ver.3.8 (2013/8/22)
 - The official INTER-Mediator site is http://inter-mediator.org/.
 - $scriptPathPrefix and $scriptPathSufix in params.php are obsoleted. Use $callURL to specify the url directly.


### PR DESCRIPTION
Fix display unnecessary insert button and delete button on the navigation bar after pressing an "enter" key in the text box of the moving page control on the navigation bar (WebKit browsers only)
