### PR TITLE
Fix DataConverter_FMDateTime and DataConverter_MySQLDateTime's issue on Windows

### DIFF
--- a/develop-im/INTER-Mediator/DataConverter_FMDateTime.php
+++ b/develop-im/INTER-Mediator/DataConverter_FMDateTime.php
@@ -40,14 +40,14 @@ class DataConverter_FMDateTime
             $sep = explode(' ', $str);
             $comp = explode('/', $sep[0]);
             $dtObj = new DateTime($comp[2] . '-' . $comp[0] . '-' . $comp[1] . ' ' . $sep[1]);
-            $fmt = '%x %T';
+            $fmt = '%x %H:%M:%S';
         } elseif (($sp === FALSE) && ($slash === 2) && ($colon === 0)) {
             $comp = explode('/', $str);
             $dtObj = new DateTime($comp[2] . '-' . $comp[0] . '-' . $comp[1]);
             $fmt = '%x';
         } elseif (($sp === FALSE) && ($slash === 0) && ($colon === 2)) {
             $dtObj = new DateTime($str);
-            $fmt = '%T';
+            $fmt = '%H:%M:%S';
         }
         if ($dtObj === false) {
             return $str;

--- a/develop-im/INTER-Mediator/DataConverter_MySQLDateTime.php
+++ b/develop-im/INTER-Mediator/DataConverter_MySQLDateTime.php
@@ -39,7 +39,7 @@ class DataConverter_MySQLDateTime
             $comp = explode('-', $sep[0]);
             $dtObj = new DateTime($comp[0] . '-' . $comp[1] . '-' . $comp[2]
                 . ' ' . $sep[1], new DateTimeZone($this->tz));
-            $fmt = '%x %T';
+            $fmt = '%x %H:%M:%S';
         } elseif (($sp === FALSE) && ($slash == 2) && ($colon == 0)) {
             $comp = explode('-', $str);
             $dtObj = new DateTime($comp[0] . '-' . $comp[1] . '-' . $comp[2],
@@ -47,7 +47,7 @@ class DataConverter_MySQLDateTime
             $fmt = '%x';
         } elseif (($sp === FALSE) && ($slash == 0) && ($colon == 2)) {
             $dtObj = new DateTime($str, new DateTimeZone($this->tz));
-            $fmt = '%T';
+            $fmt = '%H:%M:%S';
         }
         if ($dtObj === false) {
             return $str;

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -50,6 +50,7 @@ Change Log
 Latest changes might exist on the GitHub repository. Please check https://github.com/msyk/INTER-Mediator.
 
 Ver.3.10-dev
+- [BUG FIX] Fix DataConverter_FMDateTime and DataConverter_MySQLDateTime's issue on Windows.
 
 Ver.3.9 (2013/9/28)
 - The definition file editor works reading/writing. You can call it at the start of logs on debug mode.


### PR DESCRIPTION
"%T" formatting codes for strftime is not available on Windows. Now sample applications works for me on Windows Server.
