### PR TITLE
Fix DB_FileMaker_FX.php of Version 4.1-dev

### DIFF
--- a/DB_FileMaker_FX.php
+++ b/DB_FileMaker_FX.php
@@ -663,7 +663,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                         . "code={$result['errorCode']}, url={$result['URL']}<hr>"));
                     return false;
                 }
-                $this->updatedRecord = createRecordset($result['data'], $dataSourceName, null, null, null);
+                $this->updatedRecord = $this->createRecordset($result['data'], $dataSourceName, null, null, null);
                 $this->logger->setDebugMessage($this->stringWithoutCredential($result['URL']));
                 break;
             }
@@ -792,7 +792,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                 $keyValue = $row[$keyFieldName][0];
             }
         }
-        $this->updatedRecord = createRecordset($result['data'], $dataSourceName, null, null, null);
+        $this->updatedRecord = $this->createRecordset($result['data'], $dataSourceName, null, null, null);
         return $keyValue;
     }
 


### PR DESCRIPTION
Fix DB_FileMaker_FX.php to avoid outputting an error message 'Call to undefined function createRecordset()'
