### PR TITLE
Add test cases for DataConverter_HTMLString.php and update DataConverter_HTMLString.php for linking

### DIFF
--- a/DataConverter_HTMLString.php
+++ b/DataConverter_HTMLString.php
@@ -1,9 +1,8 @@
 <?php
-
 /*
  * INTER-Mediator Ver.@@@@2@@@@ Released @@@@1@@@@
  *
- *   by Masayuki Nii  msyk@msyk.net Copyright (c) 2010 Masayuki Nii, All rights reserved.
+ *   by Masayuki Nii  msyk@msyk.net Copyright (c) 2010-2014 Masayuki Nii, All rights reserved.
  *
  *   This project started at the end of 2009.
  *   INTER-Mediator is supplied under MIT License.
@@ -35,10 +34,8 @@ class DataConverter_HTMLString
                                     str_replace("&", "&amp;", $str))))))));
         if ($this->linking) {
             $str = mb_ereg_replace("(https?|ftp)(:\\/\\/[-_.!~*\\'()a-zA-Z0-9;\\/?:\\@&=+\\$,%#]+)",
-                "<a href=\"\\0\" target='_blank'>\\0</a>", $str, "i");
+                "<a href=\"\\0\" target=\"_blank\">\\0</a>", $str, "i");
         }
         return $str;
     }
 }
-
-?>

--- a/INTER-Mediator-UnitTest/DataConverter_HTMLString_Test.php
+++ b/INTER-Mediator-UnitTest/DataConverter_HTMLString_Test.php
@@ -12,6 +12,7 @@ class DataConverter_HTMLString_Test extends PHPUnit_Framework_TestCase
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'ja';
         
         $this->dataconverter = new DataConverter_HTMLString();
+        $this->dataconverterForLinking = new DataConverter_HTMLString(true);
     }
     
     public function test_converterFromUserToDB()
@@ -26,5 +27,37 @@ class DataConverter_HTMLString_Test extends PHPUnit_Framework_TestCase
         $expected = '';
         $string = '';
         $this->assertSame($expected, $this->dataconverter->converterFromDBtoUser($string));
+
+        $expected = '<br/>';
+        $string = "\n";
+        $this->assertSame($expected, $this->dataconverter->converterFromDBtoUser($string));
+
+        $expected = '<br/>';
+        $string = "\r\n";
+        $this->assertSame($expected, $this->dataconverter->converterFromDBtoUser($string));
+
+        $expected = '&gt;';
+        $string = '>';
+        $this->assertSame($expected, $this->dataconverter->converterFromDBtoUser($string));
+
+        $expected = '&lt;';
+        $string = '<';
+        $this->assertSame($expected, $this->dataconverter->converterFromDBtoUser($string));
+
+        $expected = '&#39;';
+        $string = "'";
+        $this->assertSame($expected, $this->dataconverter->converterFromDBtoUser($string));
+
+        $expected = '&quot;';
+        $string = '"';
+        $this->assertSame($expected, $this->dataconverter->converterFromDBtoUser($string));
+
+        $expected = '&amp;';
+        $string = '&';
+        $this->assertSame($expected, $this->dataconverter->converterFromDBtoUser($string));
+        
+        $expected = '<a href="http://inter-mediator.org/" target="_blank">http://inter-mediator.org/</a>';
+        $string = 'http://inter-mediator.org/';
+        $this->assertSame($expected, $this->dataconverterForLinking->converterFromDBtoUser($string));
     }
 }


### PR DESCRIPTION
Add test cases for DataConverter_HTMLString.php and update DataConverter_HTMLString.php for linking (use double quatation marks instead of single quatation marks for "target" attribute).
