### PR TITLE
DataConverter_HTMLString supports the second parameter for disabling HTML escaping

### DIFF
--- a/DB_Formatters.php
+++ b/DB_Formatters.php
@@ -2,7 +2,7 @@
 /*
  * INTER-Mediator Ver.@@@@2@@@@ Released @@@@1@@@@
  *
- *   by Masayuki Nii  msyk@msyk.net Copyright (c) 2012 Masayuki Nii, All rights reserved.
+ *   by Masayuki Nii  msyk@msyk.net Copyright (c) 2010-2014 Masayuki Nii, All rights reserved.
  *
  *   This project started at the end of 2009.
  *   INTER-Mediator is supplied under MIT License.
@@ -18,7 +18,7 @@ class DB_Formatters
 {
     private $formatter = null;
     /* Formatter processing */
-    function setFormatter($fmt)
+    public function setFormatter($fmt)
     {
         if (is_array($fmt)) {
             $this->formatter = array();
@@ -26,14 +26,20 @@ class DB_Formatters
                 if (!isset($this->formatter[$oneItem['field']])) {
                     $cvClassName = "DataConverter_{$oneItem['converter-class']}";
                     //    require_once("{$cvClassName}.php");
-                    $this->formatter[$oneItem['field']]
-                        = new $cvClassName(isset($oneItem['parameter']) ? $oneItem['parameter'] : '');
+                    if (isset($oneItem['parameter']) && is_array($oneItem['parameter'])) {
+                        $this->formatter[$oneItem['field']]
+                            = new $cvClassName(isset($oneItem['parameter'][0]) ? $oneItem['parameter'][0] : '',
+                                isset($oneItem['parameter'][1]) ? $oneItem['parameter'][1] : '');
+                    } else {
+                        $this->formatter[$oneItem['field']]
+                            = new $cvClassName(isset($oneItem['parameter']) ? $oneItem['parameter'] : '');
+                    }
                 }
             }
         }
     }
 
-    function formatterFromDB($field, $data)
+    public function formatterFromDB($field, $data)
     {
         if (is_array($this->formatter)) {
             if (isset($this->formatter[$field])) {
@@ -43,7 +49,7 @@ class DB_Formatters
         return $data;
     }
 
-    function formatterToDB($field, $data)
+    public function formatterToDB($field, $data)
     {
         if (is_array($this->formatter)) {
             if (isset($this->formatter[$field])) {

--- a/DataConverter_HTMLString.php
+++ b/DataConverter_HTMLString.php
@@ -11,27 +11,31 @@
 class DataConverter_HTMLString
 {
     private $linking;
+    private $escape;
 
-    function __construct($uselink = false)
+    public function __construct($uselink = false, $escape = true)
     {
         $this->linking = $uselink;
+        $this->escape = $escape;
     }
 
-    function converterFromUserToDB($str)
+    public function converterFromUserToDB($str)
     {
         return $str;
     }
 
-    function converterFromDBtoUser($str)
+    public function converterFromDBtoUser($str)
     {
-        $str = str_replace("\n", "<br/>",
-            str_replace("\r", "<br/>",
-                str_replace("\r\n", "<br/>",
-                    str_replace(">", "&gt;",
-                        str_replace("<", "&lt;",
-                            str_replace("'", "&#39;",
-                                str_replace('"', "&quot;",
-                                    str_replace("&", "&amp;", $str))))))));
+        if ($this->escape) {
+            $str = str_replace(">", "&gt;",
+                str_replace("<", "&lt;",
+                    str_replace("'", "&#39;",
+                        str_replace('"', "&quot;",
+                            str_replace("&", "&amp;", $str)))));
+        }
+        $str = str_replace("\n", "<br />",
+            str_replace("\r", "<br />",
+                str_replace("\r\n", "<br />", $str)));
         if ($this->linking) {
             $str = mb_ereg_replace("(https?|ftp)(:\\/\\/[-_.!~*\\'()a-zA-Z0-9;\\/?:\\@&=+\\$,%#]+)",
                 "<a href=\"\\0\" target=\"_blank\">\\0</a>", $str, "i");

--- a/INTER-Mediator-UnitTest/DataConverter_HTMLString_Test.php
+++ b/INTER-Mediator-UnitTest/DataConverter_HTMLString_Test.php
@@ -13,6 +13,7 @@ class DataConverter_HTMLString_Test extends PHPUnit_Framework_TestCase
         
         $this->dataconverter = new DataConverter_HTMLString();
         $this->dataconverterForLinking = new DataConverter_HTMLString(true);
+        $this->dataconverterWithoutEscaping = new DataConverter_HTMLString(false, false);
     }
     
     public function test_converterFromUserToDB()
@@ -20,6 +21,18 @@ class DataConverter_HTMLString_Test extends PHPUnit_Framework_TestCase
         $expected = '';
         $string = '';
         $this->assertSame($expected, $this->dataconverter->converterFromUserToDB($string));
+        
+        $expected = '<a href="http://inter-mediator.org/" target="_blank">http://inter-mediator.org/</a>' . "\n";
+        $string = '<a href="http://inter-mediator.org/" target="_blank">http://inter-mediator.org/</a>' . "\n";
+        $this->assertSame($expected, $this->dataconverter->converterFromUserToDB($string));
+
+        $expected = '<a href="http://inter-mediator.org/" target="_blank">http://inter-mediator.org/</a>' . "\n";
+        $string = '<a href="http://inter-mediator.org/" target="_blank">http://inter-mediator.org/</a>' . "\n";
+        $this->assertSame($expected, $this->dataconverterForLinking->converterFromUserToDB($string));
+
+        $expected = '<a href="http://inter-mediator.org/" target="_blank">http://inter-mediator.org/</a>' . "\n";
+        $string = '<a href="http://inter-mediator.org/" target="_blank">http://inter-mediator.org/</a>' . "\n";
+        $this->assertSame($expected, $this->dataconverterWithoutEscaping->converterFromUserToDB($string));
     }
     
     public function test_converterFromDBtoUser()
@@ -28,11 +41,11 @@ class DataConverter_HTMLString_Test extends PHPUnit_Framework_TestCase
         $string = '';
         $this->assertSame($expected, $this->dataconverter->converterFromDBtoUser($string));
 
-        $expected = '<br/>';
+        $expected = '<br />';
         $string = "\n";
         $this->assertSame($expected, $this->dataconverter->converterFromDBtoUser($string));
 
-        $expected = '<br/>';
+        $expected = '<br />';
         $string = "\r\n";
         $this->assertSame($expected, $this->dataconverter->converterFromDBtoUser($string));
 
@@ -59,5 +72,9 @@ class DataConverter_HTMLString_Test extends PHPUnit_Framework_TestCase
         $expected = '<a href="http://inter-mediator.org/" target="_blank">http://inter-mediator.org/</a>';
         $string = 'http://inter-mediator.org/';
         $this->assertSame($expected, $this->dataconverterForLinking->converterFromDBtoUser($string));
+        
+        $expected = '<a href="http://inter-mediator.org/" target="_blank">http://inter-mediator.org/</a><br />';
+        $string = '<a href="http://inter-mediator.org/" target="_blank">http://inter-mediator.org/</a>' . "\n";
+        $this->assertSame($expected, $this->dataconverterWithoutEscaping->converterFromDBtoUser($string));
     }
 }

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -66,6 +66,7 @@ Ver.4.2 (in development)
 - Send emails after the load/edit/new database operations.
 - INTERMediatorOnPage.processingAfterPostOnlyContext has TWO parameters.
 - DataConverter_HTMLString supports double and single quote to convert to reference character.
+- DataConverter_HTMLString supports the second parameter for disabling HTML escaping.
 - When the 'transaction' set to 'none', the update processing improved and update once for single record.
 - [BUG FIX] Fix setIdValue() of INTER-Mediator.js to enable setting the value of the field to the attribute of
   the node again when specifying the IM target and displaying multiple records.


### PR DESCRIPTION
DataConverter_HTMLString supports the second parameter for disabling HTML escaping.
If the second parameter is not specified, enable HTML escaping (default value is true).
