### PR TITLE
Update build.sh

### DIFF
--- a/dist-docs/buildup.sh
+++ b/dist-docs/buildup.sh
@@ -163,6 +163,13 @@ if [ $choice = 1 ]; then
     defeditdeffile="${buildPath}/INTER-Mediator-Support/defedit.php"
     sed 's|IM_Entry|/* IM_Entry|' "${defeditdeffile}" > /tmp/defedit.php
     cp -p /tmp/defedit.php "${defeditdeffile}"
+else
+    echo "PROCESSING: ${originalPath}/dist-docs/License.txt"
+    cp -p   "${originalPath}/dist-docs/License.txt" "${buildPath}"
+	readmeLines=`wc -l "${originalPath}/dist-docs/readme.txt" | awk '{print $1}'`
+	lines=`expr $readmeLines - 8`
+    echo "PROCESSING: ${originalPath}/dist-docs/readme.txt"
+    head -n `echo $lines` "${originalPath}/dist-docs/readme.txt" > "${buildPath}/readme.txt"
 fi
 
 find "${buildPath}" -name "\.*" -exec rm -rf {} \;


### PR DESCRIPTION
- Fix selecting build types ("2" or "3").
- Add License.txt and readme.txt in dist-docs directory when selecting build type "2" or "3".
- Add -p option of each cp command.
