### PR TITLE
Fix an error when the value of 'operator' is 'or' or 'and' in addtionalCondition with FileMaker Server

### DIFF
--- a/DB_FileMaker_FX.php
+++ b/DB_FileMaker_FX.php
@@ -1418,7 +1418,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
     public function isPossibleOperator($operator)
     {
         return !(FALSE === array_search(strtoupper($operator), array(
-                'EQ', 'CN', 'BW', 'EW', 'GT', 'GTE', 'LT', 'LTE', 'NEQ',
+                'EQ', 'CN', 'BW', 'EW', 'GT', 'GTE', 'LT', 'LTE', 'NEQ', 'AND', 'OR',
             )));
     }
 

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -9,6 +9,8 @@ Change Log will be supplied by English only.
 Latest changes might exist on the GitHub repository. Please check https://github.com/msyk/INTER-Mediator.
 
 Ver.4.4 (in development)
+- [BUG FIX] Fix an error when the value of 'operator' is 'or' or 'and' in addtionalCondition with FileMaker Server.
+  (affected version: 3.11, 4.0, 4.1, 4.2, 4.3)
 - [BUG FIX] Fix not to show the error message (message id: 1024) when updating data using Safari (version 4.3 only).
 - [BUG FIX] Fix an error in "Master-Detail Style Page" Sample for PostgreSQL (version 4.3 only).
 


### PR DESCRIPTION
Fix isPossibleOperator() of DB_FileMaker_FX class.
(Affected version: 3.11, 4.0, 4.1, 4.2, 4.3)
