### PR TITLE
Fix an error case in IMLibElement.setValueToIMNode()

### DIFF
--- a/INTER-Mediator-Element.js
+++ b/INTER-Mediator-Element.js
@@ -19,7 +19,7 @@ var IMLibElement = {
         if (!element) {
             return false;   // Or should be an error?
         }
-        if (curVal == null) {
+        if (curVal === null || curVal === false) {
             curVal = '';
         }
 

--- a/INTER-Mediator-UnitTest/INTER-Mediator-Element-test.js
+++ b/INTER-Mediator-UnitTest/INTER-Mediator-Element-test.js
@@ -1,0 +1,9 @@
+var assert = buster.assertions.assert;
+
+buster.testCase("INTER-Mediator Element Test", {
+    "IMLibElement.setValueToIMNode() should return false without TypeError (curVal.replace is not a function)": function () {
+        var tempElement = document.createElement("textarea");
+        assert.equals(IMLibElement.setValueToIMNode(tempElement, "textNode", null, true), false);
+        assert.equals(IMLibElement.setValueToIMNode(tempElement, "textNode", false, true), false);
+    }
+});

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -32,6 +32,8 @@ Ver.4.4 (in development)
 - [BUG FIX] The JS program of the Sample_chat has been modified.
 - [BUG FIX] Fix not to show the error message ("currentRecord is null - EXCEPTION-25") when using the PostOnlyContext 
   and the related context is exisiting.
+- [BUG FIX] Fix not to show the error message ("curVal.replace is not a function - EXCEPTION-27") in 
+  IMLibElement.setValueToIMNode() if the element of the parameter is a textarea element and the value is false.
 
 Ver.4.3 (2014/4/7)
 - The Local Context is supported. You can bind the context named "_" at any place in a page file.


### PR DESCRIPTION
Fix not to show the error message ("curVal.replace is not a function - EXCEPTION-27") in IMLibElement.setValueToIMNode() if the element of the parameter is a textarea element and the value is false.
