### PR TITLE
Fix outputting an alert message of the validation correctly on the post only mode

### DIFF
--- a/INTER-Mediator.js
+++ b/INTER-Mediator.js
@@ -738,6 +738,17 @@ var INTERMediator = {
                     if (contextInfo.validation) {
                         for (index in contextInfo.validation) {
                             validationInfo = contextInfo.validation[index];
+                            if (validationInfo && validationInfo.field == comp[1]) {
+                                switch (validationInfo.notify) {
+                                    case "inline":
+                                    case "end-of-sibling":
+                                        INTERMediatorLib.clearErrorMessage(linkedNodes[i]);
+                                        break;
+                                }
+                            }
+                        }
+                        for (index in contextInfo.validation) {
+                            validationInfo = contextInfo.validation[index];
                             if (validationInfo.field == comp[1]) {
                                 if (validationInfo) {
                                     result = Parser.evaluate(
@@ -762,13 +773,6 @@ var INTERMediator = {
                                         }
                                         if (INTERMediatorOnPage.doAfterValidationFailure != null) {
                                             INTERMediatorOnPage.doAfterValidationFailure(linkedNodes[i]);
-                                        }
-                                    } else {
-                                        switch (validationInfo.notify) {
-                                            case "inline":
-                                            case "end-of-sibling":
-                                                INTERMediatorLib.clearErrorMessage(linkedNodes[i]);
-                                                break;
                                         }
                                     }
                                 }

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -40,6 +40,8 @@ Ver.4.4 (in development)
   IMLibElement.setValueToIMNode() if the element of the parameter is a textarea element and the value is false.
 - [BUG FIX] Fix not to show the dialog message when the value of the Local Context is updated.
 - [BUG FIX] Avoid outputting duplicated alert messages of the validation when changing the value.
+- [BUG FIX] Enable outputting an alert message of the validation correctly when the validation rules of the field are 
+  multiple on the post only mode.
 - [WARNING] The JavaScript code editor "codemirror" isn't temporally supported for the updated version doesn't work fine.
 
 Ver.4.3 (2014/4/7)


### PR DESCRIPTION
Enable outputting an alert message of the validation correctly when the validation rules of the field are multiple on the post only mode.

If one validation is ok and another validation (of the same field) is not ok, there is a case not to show an alert message of the validation.
