### PR TITLE
Update OME.php to sending to the email address including '+' (especially for Gmail users)

### DIFF
--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -23,6 +23,7 @@ Ver.4.4 (in development)
 - Use sessionStorage for the Local Context instead of Cookie by default.
 - Cookie is now destroyed when browser is closed when the value of 'authexpired' key in a definition file is 0.
 - Divide the pagination codes to INTER-Mediator-Navi.js.
+- Update OME.php to sending to the email address including '+' (especially for Gmail users).
 - [BUG FIX] Fix compatibility when using INTERMediator.additionalCondition or INTERMediator.additionalSortKey.
   The affected version is 4.3 only (Thanks to Kentaro Suzuki).
 - [BUG FIX] Fix an error when the value of 'operator' is 'or' or 'and' in additionalCondition with FileMaker Server.

--- a/lib/mailsend/OME.php
+++ b/lib/mailsend/OME.php
@@ -158,7 +158,7 @@ class OME
      */
     public function checkEmail($address)
     {
-        if (!preg_match("/^([a-zA-Z0-9])+([a-zA-Z0-9_\.-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9\._-]+)+$/", $address)) {
+        if (!preg_match("/^([a-zA-Z0-9])+([a-zA-Z0-9_\.\+-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9\._-]+)+$/", $address)) {
             if (isset($address)) {
                 $this->errorMessage = "アドレス“{$address}”は正しくないメールアドレスです。";
             }


### PR DESCRIPTION
This pull request allows sending an email to "famlog+1@gmail.com", for example.
