### PR TITLE
Fix showing related fields not on the FileMaker's portal objects in some cases

### DIFF
--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -9,9 +9,10 @@ Change Log will be supplied by English only.
 Latest changes might exist on the GitHub repository. Please check https://github.com/msyk/INTER-Mediator.
 
 Ver.4.6 (in development)
+- In case of 'navi-control' is 'master-hide', the pagenation control is going to hide when the detail area appears.
+- Use fmresultset XML grammer internaly in getFromDB method of DB_FileMaker_FX class.
 - Add errorMessageStore(), isExistRequiredTable(), register(), unregister(), matchInRegisterd(), queryForTest(), 
   appendIntoRegisterd() and removeFromRegisterd() to DB_FileMaker_FX class.
-- In case of 'navi-control' is 'master-hide', the pagenation control is going to hide when the detail area apears.
 - [BUG FIX] DB_FileMaker_FX used the alternative data source not only the 'issuedhash' table also 'authuer' and some
   tables for authorization/authentication. Now, it uses just the 'issuedhash' table for the alternative data source.
 - [BUG FIX] Calculation for strings didn't work, ex. >...


### PR DESCRIPTION
Use fmresultset XML grammer internaly in getFromDB method of DB_FileMaker_FX class to fix.
