### PR TITLE
Fix INTER-Mediator-DoOnStart.js to avoid TypeError

### DIFF
--- a/INTER-Mediator-DoOnStart.js
+++ b/INTER-Mediator-DoOnStart.js
@@ -72,5 +72,3 @@ INTERMediatorLib.addEvent(window, "beforeunload", function (e) {
 INTERMediatorLib.addEvent(window, "unload", function (e) {
     INTERMediator_DBAdapter.unregister();
 });
-
-//IMLibEventResponder.setup();


### PR DESCRIPTION
Fix INTER-Mediator-DoOnStart.js to avoid TypeError (INTERMediatorOnPage.getEditorPath is not a function).
The last line of INTER-Mediator-DoOnStart.js should be an empty line to avoid an error.
