### PR TITLE
Omit the closing PHP tag at the end of file

### DIFF
--- a/DataConverter_AppendPrefix.php
+++ b/DataConverter_AppendPrefix.php
@@ -31,5 +31,3 @@ class DataConverter_AppendPrefix
         return $str;
     }
 }
-
-?>

--- a/DataConverter_AppendSuffix.php
+++ b/DataConverter_AppendSuffix.php
@@ -31,5 +31,3 @@ class DataConverter_AppendSuffix
         return $str;
     }
 }
-
-?>

--- a/DataConverter_Currency.php
+++ b/DataConverter_Currency.php
@@ -47,5 +47,3 @@ class DataConverter_Currency extends DataConverter_NumberBase
     }
 
 }
-
-?>

--- a/DataConverter_Number.php
+++ b/DataConverter_Number.php
@@ -31,5 +31,3 @@ class DataConverter_Number extends DataConverter_NumberBase
         return number_format((double)$str, $this->d, $this->decimalMark, $this->thSepMark);
     }
 }
-
-?>

--- a/DataConverter_template.php
+++ b/DataConverter_template.php
@@ -46,5 +46,3 @@ class DataConverter_template
     {
     }
 }
-
-?>

--- a/MessageStrings.php
+++ b/MessageStrings.php
@@ -96,5 +96,3 @@ class MessageStrings
         3102 => 'Dragged File: ',
     );
 }
-
-?>

--- a/MessageStrings_ja.php
+++ b/MessageStrings_ja.php
@@ -96,5 +96,3 @@ class MessageStrings_ja
         3102 => 'ドラッグしたファイル: ',
     );
 }
-
-?>


### PR DESCRIPTION
Related:
https://php.net/manual/en/language.basic-syntax.phptags.php
> If a file is pure PHP code, it is preferable to omit the PHP closing tag at the end of the file.