### PR TITLE
Fix compatibility with the private browse mode of Safari when handling the Local Context

### DIFF
--- a/INTER-Mediator-Context.js
+++ b/INTER-Mediator-Context.js
@@ -947,10 +947,14 @@ IMLibLocalContext = {
         } else {
             jsonString = JSON.stringify(this.store);
         }
-        if (INTERMediator.useSessionStorage === true
-            && typeof sessionStorage !== 'undefined'
-            && sessionStorage !== null) {
-            sessionStorage.setItem("_im_localcontext" + document.URL, jsonString);
+        if (INTERMediator.useSessionStorage === true && 
+            typeof sessionStorage !== 'undefined' && 
+            sessionStorage !== null) {
+            try {
+                sessionStorage.setItem("_im_localcontext" + document.URL, jsonString);
+            } catch (ex) {
+                INTERMediatorOnPage.setCookieWorker('_im_localcontext', jsonString, false, 0);
+            }
         } else {
             INTERMediatorOnPage.setCookieWorker('_im_localcontext', jsonString, false, 0);
         }
@@ -958,10 +962,14 @@ IMLibLocalContext = {
 
     unarchive: function () {
         var localContext = "";
-        if (INTERMediator.useSessionStorage === true
-            && typeof sessionStorage !== 'undefined'
-            && sessionStorage !== null) {
-            localContext = sessionStorage.getItem("_im_localcontext" + document.URL);
+        if (INTERMediator.useSessionStorage === true && 
+            typeof sessionStorage !== 'undefined' && 
+            sessionStorage !== null) {
+            try {
+                localContext = sessionStorage.getItem("_im_localcontext" + document.URL);
+            } catch (ex) {
+                localContext = INTERMediatorOnPage.getCookie('_im_localcontext');
+            }
         } else {
             localContext = INTERMediatorOnPage.getCookie('_im_localcontext');
         }

--- a/INTER-Mediator-Page.js
+++ b/INTER-Mediator-Page.js
@@ -120,8 +120,14 @@ INTERMediatorOnPage = {
         this.removeCookie("_im_username");
         this.removeCookie("_im_credential");
         this.removeCookie("_im_mediatoken");
-        if (INTERMediator.useSessionStorage === true && typeof sessionStorage !== 'undefined' && sessionStorage !== null) {
-            sessionStorage.removeItem("_im_localcontext");
+        if (INTERMediator.useSessionStorage === true && 
+            typeof sessionStorage !== 'undefined' && 
+            sessionStorage !== null) {
+            try {
+                sessionStorage.removeItem("_im_localcontext");
+            } catch (ex) {
+                this.removeCookie("_im_localcontext");
+            }
         } else {
             this.removeCookie("_im_localcontext");
         }

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -32,6 +32,7 @@ Ver.5.0 (in development)
 - Modify "Asset Management Sample" for the INTER-Mediator-Server virtual machine.
 - Thanks to Mr. Kazuaki Osawa for cooperating to clarify the platform issue about the vm build script.
 - Thanks to Ms. Naomi Hamaji for sponsored the upcomming Study Meeting.
+- [BUG FIX] Fix compatibility with the private browse mode of Safari when handling the Local Context.
 - [BUG FIX] Fix Vagrantfile, deploy.sh and recipe.rb etc. for the INTER-Mediator-Server virtual machine.
 
 Ver.4.7 (2015/1/25)


### PR DESCRIPTION
When Safari is in private browsing mode, trying to call sessionStorage.setItem() throws an exception.