### PR TITLE
Add useseparator and blankifzero option for client side data formatting experimentally

### DIFF
--- a/GenerateJSCode.php
+++ b/GenerateJSCode.php
@@ -252,9 +252,13 @@ class GenerateJSCode
                 "INTERMediatorOnPage.publickey",
                 "new biRSAKeyPair('", $publickey['e']->toHex(), "','0','", $publickey['n']->toHex(), "')");
         }
-        $localeSign = isset($appLocale)? $appLocale : ini_get("intl.default_locale");
+        $localeSign = isset($appLocale) ? $appLocale : ini_get("intl.default_locale");
         setlocale(LC_ALL, $localeSign);
-        $this->generateAssignJS("INTERMediatorOnPage.localeInfo", arrayToJS(localeconv(),""));
+        $localInfo = localeconv();
+        if ($localInfo['thousands_sep'] === '') {
+            $localInfo['thousands_sep'] = ',';
+        }
+        $this->generateAssignJS("INTERMediatorOnPage.localeInfo", arrayToJS($localInfo,""));
     }
     
     private function combineScripts($currentDir)

--- a/INTER-Mediator-Element.js
+++ b/INTER-Mediator-Element.js
@@ -11,7 +11,7 @@ var IMLibElement = {
     setValueToIMNode: function (element, curTarget, curVal, clearField) {
         var styleName, statement, currentValue, scriptNode, typeAttr, valueAttr, textNode,
             needPostValueSet = false, nodeTag, curValues, i, patterns, formattedValue = null, 
-            formatSpec, param1, mark;
+            formatSpec, formatOption, flags = {}, param1, mark;
         // IE should \r for textNode and <br> for innerHTML, Others is not required to convert
 
         if (curVal === undefined) {
@@ -26,7 +26,7 @@ var IMLibElement = {
 
         nodeTag = element.tagName;
 
-        if (clearField === true && curTarget == "") {
+        if (clearField === true && curTarget === "") {
             switch (nodeTag) {
                 case "INPUT":
                     switch (element.getAttribute("type")) {
@@ -36,6 +36,7 @@ var IMLibElement = {
                         default:
                             break;
                     }
+                    break;
                 case "SELECT":
                     break;
                 default:
@@ -48,12 +49,26 @@ var IMLibElement = {
 
         formatSpec = element.getAttribute("data-im-format");
         if (formatSpec) {
+            flags = {
+                useSeparator: false,
+                blankIfZero: false
+            };
+            formatOption = element.getAttribute("data-im-format-options");
+            if (formatOption) {
+                if (formatOption.toLowerCase().split(" ").indexOf("useseparator") > -1) {
+                    flags.useSeparator = true;
+                }
+                if (formatOption.toLowerCase().split(" ").indexOf("blankifzero") > -1) {
+                    flags.blankIfZero = true;
+                }
+            }
             patterns = [
                 /^number\(([0-9]+)\)/,
                 /^number\(\)/,
                 /^currency\(([0-9]+)\)/,
                 /^currency\(\)/,
                 /^boolean\([\"|']([\S]+)[\"|'],[\s]*[\"|']([\S]+)[\"|']\)/,
+                /^percent\(([0-9]+)\)/,
                 /^percent\(\)/
             ];
             for (i = 0; i < patterns.length; i++) {
@@ -67,18 +82,20 @@ var IMLibElement = {
                             break;
                         case 2:
                             if (param1[0].indexOf("number") > -1) {
-                                formattedValue = INTERMediatorLib.numberFormat(curVal, param1[1]);
+                                formattedValue = INTERMediatorLib.numberFormat(curVal, param1[1], flags);
                             } else if (param1[0].indexOf("currency") > -1) {
-                                formattedValue = INTERMediatorLib.currencyFormat(curVal, param1[1]);
+                                formattedValue = INTERMediatorLib.currencyFormat(curVal, param1[1], flags);
+                            } else if (param1[0].indexOf("percent") > -1) {
+                                formattedValue = INTERMediatorLib.percentFormat(curVal, param1[1], flags);
                             }
                             break;
                         default:
                             if (param1[0].indexOf("number") > -1) {
-                                formattedValue = INTERMediatorLib.numberFormat(curVal);
+                                formattedValue = INTERMediatorLib.numberFormat(curVal, flags);
                             } else if (param1[0].indexOf("currency") > -1) {
-                                formattedValue = INTERMediatorLib.currencyFormat(curVal);
+                                formattedValue = INTERMediatorLib.currencyFormat(curVal, flags);
                             } else if (param1[0].indexOf("percent") > -1) {
-                                formattedValue = INTERMediatorLib.percentFormat(curVal);
+                                formattedValue = INTERMediatorLib.percentFormat(curVal, 0, flags);
                             }
                             break;
                     }

--- a/INTER-Mediator-Lib.js
+++ b/INTER-Mediator-Lib.js
@@ -563,10 +563,7 @@ var INTERMediatorLib = {
 
     toNumber: function (str) {
         var s = '', i, c;
-        str = String(str);
-        for (i = 0; i < 10; i++) {
-            str = str.split(String.fromCharCode(65296 + i)).join(String(i));
-        }
+        str = (new String(str)).toString();
         for (i = 0; i < str.length; i++) {
             c = str.charAt(i);
             if ((c >= '0' && c <= '9') || c == '.' || c == '-' || c == this.cachedDigitSeparator[0]) {
@@ -588,11 +585,26 @@ var INTERMediatorLib = {
     /*
      digit should be a positive value. negative value doesn't support so far.
      */
-    numberFormat_Impl: function (str, digit, decimalPoint, thousandsPoint, curSymbol) {
-        var s, n, sign, power, underDot, underNumStr, pstr, roundedNum, underDecimalNum,
-            integerNum, formatted, isMinusValue;
-
+    numberFormat_Impl: function (str, digit, decimalPoint, thousandsSep, currencySymbol, flags) {
+        var s, n, prefix = "", i, sign, power, underDot, underNumStr, pstr, roundedNum, 
+            underDecimalNum, integerNum, formatted, isMinusValue;
+        
+        if (str === "" || str === null || str === undefined) {
+            return "";
+        }
+        if (String(str).substring(0, 1) === "-") {
+            prefix = "-";
+        }
+        if (String(str).match(/[-]/)) {
+            str = prefix + String(str).split("-").join("");
+        }
+        for (i = 0; i < 10; i++) {
+            str = String(str).split(String.fromCharCode(65296 + i)).join(String(i));
+        }
         n = this.toNumber(str);
+        if (isNaN(n)) {
+            return "";
+        }
         sign = INTERMediatorOnPage.localeInfo.positive_sign;
         isMinusValue = false;
         if (n < 0) {
@@ -600,105 +612,132 @@ var INTERMediatorLib = {
             n = -n;
             isMinusValue = true;
         }
+        
+        if (flags && flags.blankIfZero === true && n === 0) {
+            return "";
+        }
+
+        if (flags && flags.usePercentNotation) {
+            n = n * 100;
+        }
+
         underDot = (digit === undefined) ? INTERMediatorOnPage.localeInfo.frac_digits : this.toNumber(digit);
         power = Math.pow(10, underDot);
         roundedNum = Math.round(n * power);
         underDecimalNum = (underDot > 0) ? roundedNum % power : 0;
         integerNum = (roundedNum - underDecimalNum) / power;
-        underNumStr = (underDot > 0) ? new String(underDecimalNum) : '';
+        underNumStr = (underDot > 0) ? String(underDecimalNum) : '';
         while (underNumStr.length < underDot) {
             underNumStr = "0" + underNumStr;
         }
-        n = integerNum;
-        s = [];
-        for (n = Math.floor(n); n > 0; n = Math.floor(n / 1000)) {
-            if (n >= 1000) {
-                pstr = '000' + (n % 1000).toString();
-                s.push(pstr.substr(pstr.length - 3));
+        
+        if (flags && flags.useSeparator === true) {
+            if (n === 0) {
+                formatted = "0";
             } else {
-                s.push(n);
+                n = integerNum;
+                s = [];
+                for (n = Math.floor(n); n > 0; n = Math.floor(n / 1000)) {
+                    if (n >= 1000) {
+                        pstr = '000' + (n % 1000).toString();
+                        s.push(pstr.substr(pstr.length - 3));
+                    } else {
+                        s.push(n);
+                    }
+                }
+                formatted = sign + s.reverse().join(thousandsSep) + (underNumStr === "" ? "" : decimalPoint + underNumStr);
             }
+        } else {
+            formatted = sign + integerNum + (underNumStr === "" ? "" : decimalPoint + underNumStr);
         }
-        formatted = sign + s.reverse().join(thousandsPoint) + (underNumStr == '' ? '' : decimalPoint + underNumStr);
-        if (curSymbol) {
+        
+        if (currencySymbol) {
             if (!isMinusValue) {
                 if (INTERMediatorOnPage.localeInfo.p_cs_precedes == 1) {
                     if (INTERMediatorOnPage.localeInfo.p_sep_by_space == 1) {
-                        formatted = curSymbol + " " + formatted;
+                        formatted = currencySymbol + " " + formatted;
                     } else {
-                        formatted = curSymbol + formatted;
+                        formatted = currencySymbol + formatted;
                     }
                 } else {
                     if (INTERMediatorOnPage.localeInfo.p_sep_by_space == 1) {
-                        formatted = formatted + " " + curSymbol;
+                        formatted = formatted + " " + currencySymbol;
                     } else {
-                        formatted = formatted + curSymbol;
+                        formatted = formatted + currencySymbol;
                     }
                 }
             } else {
                 if (INTERMediatorOnPage.localeInfo.n_cs_precedes == 1) {
                     if (INTERMediatorOnPage.localeInfo.n_sep_by_space == 1) {
-                        formatted = curSymbol + " " + formatted;
+                        formatted = currencySymbol + " " + formatted;
                     } else {
-                        formatted = curSymbol + formatted;
+                        formatted = currencySymbol + formatted;
                     }
                 } else {
                     if (INTERMediatorOnPage.localeInfo.n_sep_by_space == 1) {
-                        formatted = formatted + " " + curSymbol;
+                        formatted = formatted + " " + currencySymbol;
                     } else {
-                        formatted = formatted + curSymbol;
+                        formatted = formatted + currencySymbol;
                     }
                 }
             }
         }
+        
+        if (flags && flags.usePercentNotation === true && formatted !== "") {
+            formatted = formatted + "%";
+        }
+        
         return formatted;
     },
 
-    numberFormat: function (str, digit) {
+    numberFormat: function (str, digit, flags) {
+        if (flags === undefined) {
+            flags = {};
+        }
+        flags.useSeparator = true;
         return INTERMediatorLib.numberFormat_Impl(str, digit,
             INTERMediatorOnPage.localeInfo.decimal_point,
-            INTERMediatorOnPage.localeInfo.thousands_sep);
+            INTERMediatorOnPage.localeInfo.thousands_sep,
+            false,
+            flags
+        );
     },
 
-    currencyFormat: function (str, digit) {
+    currencyFormat: function (str, digit, flags) {
         return INTERMediatorLib.numberFormat_Impl(str, digit,
             INTERMediatorOnPage.localeInfo.mon_decimal_point,
             INTERMediatorOnPage.localeInfo.mon_thousands_sep,
-            INTERMediatorOnPage.localeInfo.currency_symbol);
+            INTERMediatorOnPage.localeInfo.currency_symbol,
+            flags
+        );
     },
 
-    booleanFormat: function (str, str1, str2) {
+    booleanFormat: function (str, trueString, falseString) {
         if (str === "" || str === null) {
             return "";
         } else {
             if (parseInt(str, 10) !== 0) {
-                return str1;
+                return trueString;
             } else {
-                return str2;
+                return falseString;
             }
         }
     },
 
-    percentFormat: function (str) {
-        var prefix = "";
-        if (str === "" || str === null) {
-            return "";
-        } else {
-            str = String(str);
-            if (str.substring(0, 1) === "-") {
-                prefix = "-";
-            }
-            if (str.match(/[-]/)) {
-                str = str.split("-").join("");
-            }
-            str = String(this.toNumber(str));
-            if (str.match(/[\d]+/)) {
-                str = str.match(/\d/g).join("");
-                return prefix + String(parseInt(str, 10) * 100) + "%";
-            } else {
-                return "";
-            }
+    percentFormat: function (str, digit, flags) {
+        if (flags === undefined) {
+            flags = {};
         }
+        flags.usePercentNotation = true;
+        if (digit === undefined) {
+            digit = 0;
+        }
+        return INTERMediatorLib.numberFormat_Impl(str, digit,
+            INTERMediatorOnPage.localeInfo.decimal_point,
+            INTERMediatorOnPage.localeInfo.thousands_sep,
+            false,
+            flags
+        );
     },
 
     objectToString: function (obj) {

--- a/INTER-Mediator-UnitTest/INTER-Mediator-Lib-test.js
+++ b/INTER-Mediator-UnitTest/INTER-Mediator-Lib-test.js
@@ -50,7 +50,7 @@ buster.testCase("INTERMediatorLib.generatePasswordHash() Test", {
 });
 
 buster.testCase("INTERMediatorLib.numberFormat() Test", {
-    "small integer should not be converted.": function () {
+    setUp: function () {
         INTERMediatorOnPage.localeInfo = {
             'decimal_point': '.',
             'thousands_sep': ',',
@@ -77,7 +77,9 @@ buster.testCase("INTERMediatorLib.numberFormat() Test", {
                 '1': '3'
             }
         };
-
+    },
+    "small integer should not be converted.": function () {
+        assert.equals(INTERMediatorLib.numberFormat(0, 0), "0");
         assert.equals(INTERMediatorLib.numberFormat(45, 0), "45");
         assert.equals(INTERMediatorLib.numberFormat(45.678, 1), "45.7");
         assert.equals(INTERMediatorLib.numberFormat(45.678, 2), "45.68");
@@ -87,33 +89,6 @@ buster.testCase("INTERMediatorLib.numberFormat() Test", {
         assert.equals(INTERMediatorLib.numberFormat(45.123, 3), "45.123");
     },
     "each 3-digits should be devided.": function () {
-        INTERMediatorOnPage.localeInfo = {
-            'decimal_point': '.',
-            'thousands_sep': ',',
-            'int_curr_symbol': 'JPY ',
-            'currency_symbol': '¥',
-            'mon_decimal_point': '.',
-            'mon_thousands_sep': ',',
-            'positive_sign': '',
-            'negative_sign': '-',
-            'int_frac_digits': '0',
-            'frac_digits': '0',
-            'p_cs_precedes': '1',
-            'p_sep_by_space': '0',
-            'n_cs_precedes': '1',
-            'n_sep_by_space': '0',
-            'p_sign_posn': '1',
-            'n_sign_posn': '4',
-            'grouping': {
-                '0': '3',
-                '1': '3'
-            },
-            'mon_grouping': {
-                '0': '3',
-                '1': '3'
-            }
-        };
-
         assert.equals(INTERMediatorLib.numberFormat(999, 0), "999");
         assert.equals(INTERMediatorLib.numberFormat(1000, 0), "1,000");
         assert.equals(INTERMediatorLib.numberFormat(999999, 0), "999,999");
@@ -129,6 +104,16 @@ buster.testCase("INTERMediatorLib.numberFormat() Test", {
         assert.equals(INTERMediatorLib.numberFormat(999999, -2), "1,000,000");
         assert.equals(INTERMediatorLib.numberFormat(999999, -3), "1,000,000");
         // A negative second parameter doesn't support so far.
+    },
+    "INTERMediatorLib.numberFormat(0) should return \"\" if blankifzero is enabled.": function () {
+        var flags = { blankIfZero: true };
+        assert.equals(INTERMediatorLib.numberFormat("0", 0, flags), "");
+        assert.equals(INTERMediatorLib.numberFormat("０", 0, flags), "");
+        assert.equals(INTERMediatorLib.numberFormat("0.", 0, flags), "");
+    },
+    "INTERMediatorLib.numberFormat(1) should return \"1\" if blankifzero is enabled.": function () {
+        var flags = { blankIfZero: true };
+        assert.equals(INTERMediatorLib.numberFormat("1", 0, flags), "1");
     },
     "format string detection": function()   {
         assert.equals(INTERMediatorLib.digitSeparator(), [".", ",", 3]);
@@ -169,7 +154,35 @@ buster.testCase("INTERMediatorLib.booleanFormat() Test", {
     }
 });
 
-buster.testCase("INTERMediatorLib.percnetFormat() Test", {
+buster.testCase("INTERMediatorLib.percentFormat() Test", {
+    setUp: function () {
+        INTERMediatorOnPage.localeInfo = {
+            'decimal_point': '.',
+            'thousands_sep': ',',
+            'int_curr_symbol': 'JPY ',
+            'currency_symbol': '¥',
+            'mon_decimal_point': '.',
+            'mon_thousands_sep': ',',
+            'positive_sign': '',
+            'negative_sign': '-',
+            'int_frac_digits': '0',
+            'frac_digits': '0',
+            'p_cs_precedes': '1',
+            'p_sep_by_space': '0',
+            'n_cs_precedes': '1',
+            'n_sep_by_space': '0',
+            'p_sign_posn': '1',
+            'n_sign_posn': '4',
+            'grouping': {
+                '0': '3',
+                '1': '3'
+            },
+            'mon_grouping': {
+                '0': '3',
+                '1': '3'
+            }
+        };
+    },
     "should return \"\" if the parameter is \"\"": function () {
         assert.equals(INTERMediatorLib.percentFormat(""), "");
     },
@@ -199,6 +212,9 @@ buster.testCase("INTERMediatorLib.percnetFormat() Test", {
     },
     "should return \"\" if the parameter is \"６７-0\"": function () {
         assert.equals(INTERMediatorLib.percentFormat("６７-0"), "67000%");
+    },
+    "should return \"\" if the parameter is \"0.1\"": function () {
+        assert.equals(INTERMediatorLib.percentFormat("0.1"), "10%");
     }
 });
 

--- a/INTER-Mediator-UnitTest/js-expression-eval-test.js
+++ b/INTER-Mediator-UnitTest/js-expression-eval-test.js
@@ -54,6 +54,34 @@ buster.testCase("Operators Test2", {
 });
 
 buster.testCase("Functions Test", {
+    setUp: function () {
+        INTERMediatorOnPage.localeInfo = {
+            'decimal_point': '.',
+            'thousands_sep': ',',
+            'int_curr_symbol': 'JPY ',
+            'currency_symbol': '¥',
+            'mon_decimal_point': '.',
+            'mon_thousands_sep': ',',
+            'positive_sign': '',
+            'negative_sign': '-',
+            'int_frac_digits': '0',
+            'frac_digits': '0',
+            'p_cs_precedes': '1',
+            'p_sep_by_space': '0',
+            'n_cs_precedes': '1',
+            'n_sep_by_space': '0',
+            'p_sign_posn': '1',
+            'n_sign_posn': '4',
+            'grouping': {
+                '0': '3',
+                '1': '3'
+            },
+            'mon_grouping': {
+                '0': '3',
+                '1': '3'
+            }
+        };
+    },
     "should be equal to": function () {
         assert.equals(Math.round(Parser.evaluate("sin(PI/4)") * 100), 71);
         assert.equals(Math.round(Parser.evaluate("cos(PI/4)") * 100), 71);
@@ -91,7 +119,7 @@ buster.testCase("Functions Test", {
         assert.equals(Math.round(Parser.evaluate("log(0.5)") * 100), -69);
         var x = Parser.evaluate("random()");
         assert.equals(x > 0 && x < 1, true);
-        var x = Parser.evaluate("random()+1");
+        x = Parser.evaluate("random()+1");
         assert.equals(x > 1 && x < 2, true);
         assert.equals(Parser.evaluate("pow(2,3)"), 8);
         assert.equals(Parser.evaluate("min(3,1,2,1,5,1)"), 1);
@@ -117,7 +145,7 @@ buster.testCase("INTER-Mediator Specific Calculation Test: ", {
         var exp, vals, result;
 
         exp = "dog * cat";
-        vals = {dog: [20], cat: [4]}
+        vals = {dog: [20], cat: [4]};
         result = Parser.evaluate(exp, vals);
         assert.equals(result, 80);
     },


### PR DESCRIPTION
Added useseparator and blankifzero option for client side data formatting using "data-im-format-options" attribute.