### PR TITLE
Add decimalFormat method for client side data formatting experimentally

### DIFF
--- a/INTER-Mediator-Element.js
+++ b/INTER-Mediator-Element.js
@@ -104,7 +104,7 @@ var IMLibElement = {
                             break;
                         case 2:
                             if (param1[0].indexOf("number") > -1) {
-                                formattedValue = INTERMediatorLib.numberFormat(curVal, param1[1], flags);
+                                formattedValue = INTERMediatorLib.decimalFormat(curVal, param1[1], flags);
                             } else if (param1[0].indexOf("currency") > -1) {
                                 formattedValue = INTERMediatorLib.currencyFormat(curVal, param1[1], flags);
                             } else if (param1[0].indexOf("percent") > -1) {
@@ -113,7 +113,7 @@ var IMLibElement = {
                             break;
                         default:
                             if (param1[0].indexOf("number") > -1) {
-                                formattedValue = INTERMediatorLib.numberFormat(curVal, 0, flags);
+                                formattedValue = INTERMediatorLib.decimalFormat(curVal, 0, flags);
                             } else if (param1[0].indexOf("currency") > -1) {
                                 formattedValue = INTERMediatorLib.currencyFormat(curVal, 0, flags);
                             } else if (param1[0].indexOf("percent") > -1) {

--- a/INTER-Mediator-Lib.js
+++ b/INTER-Mediator-Lib.js
@@ -605,34 +605,37 @@ var INTERMediatorLib = {
         if (isNaN(n)) {
             return "";
         }
+        
+        if (flags === undefined) {
+            flags = {};
+        }
+
         sign = INTERMediatorOnPage.localeInfo.positive_sign;
         isMinusValue = false;
         if (n < 0) {
             sign = INTERMediatorOnPage.localeInfo.negative_sign;
-            if (flags) {
-                if (flags.negativeStyle === 0 || flags.negativeStyle === 1) {
-                    sign = "-";
-                } else if (flags.negativeStyle === 2) {
-                    sign = "(";
-                    tailSign = ")";
-                } else if (flags.negativeStyle === 3) {
-                    sign = "<";
-                    tailSign = ">";
-                } else if (flags.negativeStyle === 4) {
-                    sign = " CR";
-                } else if (flags.negativeStyle === 5) {
-                    sign = "▲";
-                }
+            if (flags.negativeStyle === 0 || flags.negativeStyle === 1) {
+                sign = "-";
+            } else if (flags.negativeStyle === 2) {
+                sign = "(";
+                tailSign = ")";
+            } else if (flags.negativeStyle === 3) {
+                sign = "<";
+                tailSign = ">";
+            } else if (flags.negativeStyle === 4) {
+                sign = " CR";
+            } else if (flags.negativeStyle === 5) {
+                sign = "▲";
             }
             n = -n;
             isMinusValue = true;
         }
 
-        if (flags && flags.blankIfZero === true && n === 0) {
+        if (flags.blankIfZero === true && n === 0) {
             return "";
         }
 
-        if (flags && flags.usePercentNotation) {
+        if (flags.usePercentNotation) {
             n = n * 100;
         }
 
@@ -646,7 +649,7 @@ var INTERMediatorLib = {
             underNumStr = "0" + underNumStr;
         }
 
-        if (flags && flags.useSeparator === true) {
+        if (flags.useSeparator === true) {
             if (n === 0) {
                 formatted = "0";
             } else {
@@ -661,11 +664,11 @@ var INTERMediatorLib = {
                     }
                 }
                 formatted = s.reverse().join(thousandsSep) + (underNumStr === "" ? "" : decimalPoint + underNumStr);
-                if (flags && (flags.negativeStyle === 0 || flags.negativeStyle === 5)) {
+                if (flags.negativeStyle === 0 || flags.negativeStyle === 5) {
                     formatted = sign + formatted;
-                } else if (flags && (flags.negativeStyle === 1 || flags.negativeStyle === 4)) {
+                } else if (flags.negativeStyle === 1 || flags.negativeStyle === 4) {
                     formatted = formatted + sign;
-                } else if (flags && (flags.negativeStyle === 2 || flags.negativeStyle === 3)) {
+                } else if (flags.negativeStyle === 2 || flags.negativeStyle === 3) {
                     formatted = sign + formatted + tailSign;
                 } else {
                     formatted = sign + formatted;
@@ -673,11 +676,11 @@ var INTERMediatorLib = {
             }
         } else {
             formatted = integerNum + (underNumStr === "" ? "" : decimalPoint + underNumStr);
-            if (flags && (flags.negativeStyle === 0 || flags.negativeStyle === 5)) {
+            if (flags.negativeStyle === 0 || flags.negativeStyle === 5) {
                 formatted = sign + formatted;
-            } else if (flags && (flags.negativeStyle === 1 || flags.negativeStyle === 4)) {
+            } else if (flags.negativeStyle === 1 || flags.negativeStyle === 4) {
                 formatted = formatted + sign;
-            } else if (flags && (flags.negativeStyle === 2 || flags.negativeStyle === 3)) {
+            } else if (flags.negativeStyle === 2 || flags.negativeStyle === 3) {
                 formatted = sign + formatted + tailSign;
             } else {
                 formatted = sign + formatted;
@@ -716,7 +719,7 @@ var INTERMediatorLib = {
             }
         }
         
-        if (flags && flags.usePercentNotation === true && formatted !== "") {
+        if (flags.usePercentNotation === true && formatted !== "") {
             formatted = formatted + "%";
         }
         
@@ -727,7 +730,11 @@ var INTERMediatorLib = {
         if (flags === undefined) {
             flags = {};
         }
-        flags.useSeparator = true;
+        flags.useSeparator = true;    // for compatibility
+        return this.decimalFormat(str, digit, flags);
+    },
+    
+    decimalFormat: function (str, digit, flags) {
         return INTERMediatorLib.numberFormat_Impl(str, digit,
             INTERMediatorOnPage.localeInfo.decimal_point,
             INTERMediatorOnPage.localeInfo.thousands_sep,

--- a/INTER-Mediator-UnitTest/INTER-Mediator-Lib-test.js
+++ b/INTER-Mediator-UnitTest/INTER-Mediator-Lib-test.js
@@ -79,33 +79,6 @@ buster.testCase("INTERMediatorLib.numberFormat() Test", {
         };
     },
     "small integer should not be converted.": function () {
-        INTERMediatorOnPage.localeInfo = {
-            'decimal_point': '.',
-            'thousands_sep': ',',
-            'int_curr_symbol': 'JPY ',
-            'currency_symbol': '¥',
-            'mon_decimal_point': '.',
-            'mon_thousands_sep': ',',
-            'positive_sign': '',
-            'negative_sign': '-',
-            'int_frac_digits': '0',
-            'frac_digits': '0',
-            'p_cs_precedes': '1',
-            'p_sep_by_space': '0',
-            'n_cs_precedes': '1',
-            'n_sep_by_space': '0',
-            'p_sign_posn': '1',
-            'n_sign_posn': '4',
-            'grouping': {
-                '0': '3',
-                '1': '3'
-            },
-            'mon_grouping': {
-                '0': '3',
-                '1': '3'
-            }
-        };
-
         assert.equals(INTERMediatorLib.numberFormat(45, 0), "45");
         assert.equals(INTERMediatorLib.numberFormat(45.678, 1), "45.7");
         assert.equals(INTERMediatorLib.numberFormat(45.678, 2), "45.68");
@@ -115,33 +88,6 @@ buster.testCase("INTERMediatorLib.numberFormat() Test", {
         assert.equals(INTERMediatorLib.numberFormat(45.123, 3), "45.123");
     },
     "each 3-digits should be devided.": function () {
-        INTERMediatorOnPage.localeInfo = {
-            'decimal_point': '.',
-            'thousands_sep': ',',
-            'int_curr_symbol': 'JPY ',
-            'currency_symbol': '¥',
-            'mon_decimal_point': '.',
-            'mon_thousands_sep': ',',
-            'positive_sign': '',
-            'negative_sign': '-',
-            'int_frac_digits': '0',
-            'frac_digits': '0',
-            'p_cs_precedes': '1',
-            'p_sep_by_space': '0',
-            'n_cs_precedes': '1',
-            'n_sep_by_space': '0',
-            'p_sign_posn': '1',
-            'n_sign_posn': '4',
-            'grouping': {
-                '0': '3',
-                '1': '3'
-            },
-            'mon_grouping': {
-                '0': '3',
-                '1': '3'
-            }
-        };
-
         assert.equals(INTERMediatorLib.numberFormat(999, 0), "999");
         assert.equals(INTERMediatorLib.numberFormat(1000, 0), "1,000");
         assert.equals(INTERMediatorLib.numberFormat(999999, 0), "999,999");
@@ -158,18 +104,91 @@ buster.testCase("INTERMediatorLib.numberFormat() Test", {
         assert.equals(INTERMediatorLib.numberFormat(999999, -3), "1,000,000");
         // A negative second parameter doesn't support so far.
     },
-    "INTERMediatorLib.numberFormat(0) should return \"\" if blankifzero is enabled.": function () {
-        var flags = { blankIfZero: true };
-        assert.equals(INTERMediatorLib.numberFormat("0", 0, flags), "");
-        assert.equals(INTERMediatorLib.numberFormat("０", 0, flags), "");
-        assert.equals(INTERMediatorLib.numberFormat("0.", 0, flags), "");
-    },
-    "INTERMediatorLib.numberFormat(1) should return \"1\" if blankifzero is enabled.": function () {
-        var flags = { blankIfZero: true };
-        assert.equals(INTERMediatorLib.numberFormat("1", 0, flags), "1");
-    },
     "format string detection": function() {
         assert.equals(INTERMediatorLib.digitSeparator(), [".", ",", 3]);
+    }
+});
+
+buster.testCase("INTERMediatorLib.decimalFormat() Test", {
+    setUp: function () {
+        INTERMediatorOnPage.localeInfo = {
+            'decimal_point': '.',
+            'thousands_sep': ',',
+            'int_curr_symbol': 'JPY ',
+            'currency_symbol': '¥',
+            'mon_decimal_point': '.',
+            'mon_thousands_sep': ',',
+            'positive_sign': '',
+            'negative_sign': '-',
+            'int_frac_digits': '0',
+            'frac_digits': '0',
+            'p_cs_precedes': '1',
+            'p_sep_by_space': '0',
+            'n_cs_precedes': '1',
+            'n_sep_by_space': '0',
+            'p_sign_posn': '1',
+            'n_sign_posn': '4',
+            'grouping': {
+                '0': '3',
+                '1': '3'
+            },
+            'mon_grouping': {
+                '0': '3',
+                '1': '3'
+            }
+        };
+    },
+    "small integer should not be converted.": function () {
+        assert.equals(INTERMediatorLib.decimalFormat(45, 0), "45");
+        assert.equals(INTERMediatorLib.decimalFormat(45.678, 1), "45.7");
+        assert.equals(INTERMediatorLib.decimalFormat(45.678, 2), "45.68");
+        assert.equals(INTERMediatorLib.decimalFormat(45.678, 3), "45.678");
+        assert.equals(INTERMediatorLib.decimalFormat(45.123, 1), "45.1");
+        assert.equals(INTERMediatorLib.decimalFormat(45.123, 2), "45.12");
+        assert.equals(INTERMediatorLib.decimalFormat(45.123, 3), "45.123");
+    },
+    "each 3-digits should not be devided.": function () {
+        assert.equals(INTERMediatorLib.decimalFormat(999, 0), "999");
+        assert.equals(INTERMediatorLib.decimalFormat(1000, 0), "1000");
+        assert.equals(INTERMediatorLib.decimalFormat(999999, 0), "999999");
+        assert.equals(INTERMediatorLib.decimalFormat(1000000, 0), "1000000");
+        assert.equals(INTERMediatorLib.decimalFormat(1000000.678, 1), "1000000.7");
+        assert.equals(INTERMediatorLib.decimalFormat(1000000.678, 2), "1000000.68");
+        assert.equals(INTERMediatorLib.decimalFormat(1000000.678, 3), "1000000.678");
+        assert.equals(INTERMediatorLib.decimalFormat(1000000.678, 4), "1000000.6780");
+        assert.equals(INTERMediatorLib.decimalFormat(-1000000.678, 1), "-1000000.7");
+        assert.equals(INTERMediatorLib.decimalFormat(-1000000.678, 2), "-1000000.68");
+        assert.equals(INTERMediatorLib.decimalFormat(-1000000.678, 3), "-1000000.678");
+        assert.equals(INTERMediatorLib.decimalFormat(999999, -1), "1000000");
+        assert.equals(INTERMediatorLib.decimalFormat(999999, -2), "1000000");
+        assert.equals(INTERMediatorLib.decimalFormat(999999, -3), "1000000");
+    },
+    "each 3-digits should be devided \"\" if useseperator is enabled.": function () {
+        var flags = { useSeparator: true };
+        assert.equals(INTERMediatorLib.decimalFormat(999, 0, flags), "999");
+        assert.equals(INTERMediatorLib.decimalFormat(1000, 0, flags), "1,000");
+        assert.equals(INTERMediatorLib.decimalFormat(999999, 0, flags), "999,999");
+        assert.equals(INTERMediatorLib.decimalFormat(1000000, 0, flags), "1,000,000");
+        assert.equals(INTERMediatorLib.decimalFormat(1000000.678, 1, flags), "1,000,000.7");
+        assert.equals(INTERMediatorLib.decimalFormat(1000000.678, 2, flags), "1,000,000.68");
+        assert.equals(INTERMediatorLib.decimalFormat(1000000.678, 3, flags), "1,000,000.678");
+        assert.equals(INTERMediatorLib.decimalFormat(1000000.678, 4, flags), "1,000,000.6780");
+        assert.equals(INTERMediatorLib.decimalFormat(-1000000.678, 1, flags), "-1,000,000.7");
+        assert.equals(INTERMediatorLib.decimalFormat(-1000000.678, 2, flags), "-1,000,000.68");
+        assert.equals(INTERMediatorLib.decimalFormat(-1000000.678, 3, flags), "-1,000,000.678");
+        assert.equals(INTERMediatorLib.decimalFormat(999999, -1, flags), "1,000,000");
+        assert.equals(INTERMediatorLib.decimalFormat(999999, -2, flags), "1,000,000");
+        assert.equals(INTERMediatorLib.decimalFormat(999999, -3, flags), "1,000,000");
+    },
+    "INTERMediatorLib.decimalFormat(0) should return \"\" if blankifzero is enabled.": function () {
+        var flags = { blankIfZero: true };
+        assert.equals(INTERMediatorLib.decimalFormat("0", 0, flags), "");
+        assert.equals(INTERMediatorLib.decimalFormat("０", 0, flags), "");
+        assert.equals(INTERMediatorLib.decimalFormat("0.", 0, flags), "");
+    },
+    "INTERMediatorLib.decimalFormat(1) should return \"1\" if blankifzero is enabled.": function () {
+        var flags = { blankIfZero: true };
+        assert.equals(INTERMediatorLib.decimalFormat("1", 0, flags), "1");
     }
 });
 

--- a/INTER-Mediator-UnitTest/js-expression-eval-test.js
+++ b/INTER-Mediator-UnitTest/js-expression-eval-test.js
@@ -54,6 +54,34 @@ buster.testCase("Operators Test2", {
 });
 
 buster.testCase("Functions Test", {
+    setUp: function () {
+        INTERMediatorOnPage.localeInfo = {
+            'decimal_point': '.',
+            'thousands_sep': ',',
+            'int_curr_symbol': 'JPY ',
+            'currency_symbol': '¥',
+            'mon_decimal_point': '.',
+            'mon_thousands_sep': ',',
+            'positive_sign': '',
+            'negative_sign': '-',
+            'int_frac_digits': '0',
+            'frac_digits': '0',
+            'p_cs_precedes': '1',
+            'p_sep_by_space': '0',
+            'n_cs_precedes': '1',
+            'n_sep_by_space': '0',
+            'p_sign_posn': '1',
+            'n_sign_posn': '4',
+            'grouping': {
+                '0': '3',
+                '1': '3'
+            },
+            'mon_grouping': {
+                '0': '3',
+                '1': '3'
+            }
+        };
+    },
     "should be equal to": function () {
         assert.equals(Math.round(Parser.evaluate("sin(PI/4)") * 100), 71);
         assert.equals(Math.round(Parser.evaluate("cos(PI/4)") * 100), 71);
@@ -91,7 +119,7 @@ buster.testCase("Functions Test", {
         assert.equals(Math.round(Parser.evaluate("log(0.5)") * 100), -69);
         var x = Parser.evaluate("random()");
         assert.equals(x > 0 && x < 1, true);
-        var x = Parser.evaluate("random()+1");
+        x = Parser.evaluate("random()+1");
         assert.equals(x > 1 && x < 2, true);
         assert.equals(Parser.evaluate("pow(2,3)"), 8);
         assert.equals(Parser.evaluate("min(3,1,2,1,5,1)"), 1);
@@ -117,7 +145,7 @@ buster.testCase("INTER-Mediator Specific Calculation Test: ", {
         var exp, vals, result;
 
         exp = "dog * cat";
-        vals = {dog: [20], cat: [4]}
+        vals = {dog: [20], cat: [4]};
         result = Parser.evaluate(exp, vals);
         assert.equals(result, 80);
     },
@@ -125,7 +153,7 @@ buster.testCase("INTER-Mediator Specific Calculation Test: ", {
         var exp, vals, result;
 
         exp = "dog * cat";
-        vals = {dog: [29], cat: [4.1]}
+        vals = {dog: [29], cat: [4.1]};
         result = Parser.evaluate(exp, vals);
         assert.equals(INTERMediatorLib.Round(result, 1), 118.9);
     },
@@ -166,7 +194,7 @@ buster.testCase("INTER-Mediator Specific Calculation Test: ", {
         var exp, vals, result;
 
         exp = "dog + cat";
-        vals = {dog: ["Bowwow!"], cat: ["Mewww"]}
+        vals = {dog: ["Bowwow!"], cat: ["Mewww"]};
         result = Parser.evaluate(exp, vals);
         assert.equals(result, "Bowwow!Mewww");
     },
@@ -174,7 +202,7 @@ buster.testCase("INTER-Mediator Specific Calculation Test: ", {
         var exp, vals, result;
 
         exp = "dog + cat";
-        vals = {dog: ["Bowwow!"], cat: ["4.3"]}
+        vals = {dog: ["Bowwow!"], cat: ["4.3"]};
         result = Parser.evaluate(exp, vals);
         assert.equals(result, "Bowwow!4.3");
     },
@@ -196,12 +224,12 @@ buster.testCase("INTER-Mediator Specific Calculation Test: ", {
     },
     "Wrong expression.1": function () {
         assert.exception(function () {
-            Parser.evaluate("(a + b", {'a': [20], 'b': [2]})
+            Parser.evaluate("(a + b", {'a': [20], 'b': [2]});
         });
     },
     "Wrong expression.2": function () {
         assert.exception(function () {
-            Parser.evaluate("a + b + malfunction(a)", {'a': [20], 'b': [2]})
+            Parser.evaluate("a + b + malfunction(a)", {'a': [20], 'b': [2]});
         });
     },
 


### PR DESCRIPTION
Added INTERMediatorLib.decimalFormat(). I have considered the compatibility of INTERMediatorLib.numberFormat( str, digit ) and "useseparator" option for client side data formatting.