### PR TITLE
Update deploy.sh to avoid "vagrant up" failing

### DIFF
--- a/dist-docs/vm-for-trial/deploy.sh
+++ b/dist-docs/vm-for-trial/deploy.sh
@@ -37,6 +37,7 @@ echo "default-character-set=utf8mb4" >> /etc/mysql/conf.d/im.cnf
 echo "[mysql]" >> /etc/mysql/conf.d/im.cnf
 echo "default-character-set=utf8mb4" >> /etc/mysql/conf.d/im.cnf
 
+echo "set grub-pc/install_devices /dev/sda" | debconf-communicate
 aptitude update
 aptitude full-upgrade --assume-yes
 aptitude install sqlite --assume-yes


### PR DESCRIPTION
I have updated deploy.sh to avoid "vagrant up" failing due to the updated "grub-pc" package.