### PR TITLE
Update deploy.sh for the INTER-Mediator-Server

### DIFF
--- a/dist-docs/vm-for-trial/deploy.sh
+++ b/dist-docs/vm-for-trial/deploy.sh
@@ -165,7 +165,7 @@ echo "   path = /var/www/html" >> "${SMBCONF}"
 echo "   guest ok = no" >> "${SMBCONF}"
 echo "   browseable = yes" >> "${SMBCONF}"
 echo "   read only = no" >> "${SMBCONF}"
-echo "   create mask = 0770" >> "${SMBCONF}"
+echo "   create mask = 0775" >> "${SMBCONF}"
 ( echo im4135dev; echo im4135dev ) | sudo smbpasswd -s -a developer
 
 # Launch buster-server for unit testing

--- a/dist-docs/vm-for-trial/recipe.rb
+++ b/dist-docs/vm-for-trial/recipe.rb
@@ -1016,7 +1016,7 @@ file "#{SMBCONF}" do
    guest ok = no
    browseable = yes
    read only = no
-   create mask = 0770
+   create mask = 0775
 EOF
 end
 

--- a/dist-docs/vm-for-trial/spec/192.168.56.101/sample_spec.rb
+++ b/dist-docs/vm-for-trial/spec/192.168.56.101/sample_spec.rb
@@ -398,7 +398,7 @@ describe file('/etc/samba/smb.conf') do
   its(:content) { should match /guest ok = no/ }
   its(:content) { should match /browseable = yes/ }
   its(:content) { should match /read only = no/ }
-  its(:content) { should match /create mask = 0770/ }
+  its(:content) { should match /create mask = 0775/ }
 end
 
 describe file('/home/developer/.bashrc') do


### PR DESCRIPTION
I have modified the setting of Samba.
Because when creating a new file in the webroot directory via SMB, the web browser can't browse the new file.