### PR TITLE
Fix an error when the value of 'operator' key in 'query' key is '=' in a definition file using FileMaker Server

### DIFF
--- a/DB_FileMaker_FX.php
+++ b/DB_FileMaker_FX.php
@@ -90,7 +90,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
             $this->errorMessageStore("The table doesn't specified.");
             return false;
         }
-        
+
         $this->setupFXforDB($regTable, 1);
         $this->fxResult = $this->fx->DoFxAction('show_all', TRUE, TRUE, 'full');
         if ($this->fxResult['errorCode'] != 0 && $this->fxResult['errorCode'] != 401) {
@@ -114,7 +114,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
         $result = $this->fx->DoFxAction('new', TRUE, TRUE, 'full');
         if (!is_array($result)) {
             $this->errorMessageStore(
-                $this->stringWithoutCredential("FX reports error at insert action: " . 
+                $this->stringWithoutCredential("FX reports error at insert action: " .
                     "code={$result['errorCode']}, url={$result['URL']}"));
             return false;
         }
@@ -134,10 +134,10 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                 $result = $this->fx->DoFxAction('new', TRUE, TRUE, 'full');
                 if (!is_array($result)) {
                     $this->logger->setDebugMessage(
-                        $this->stringWithoutCredential("FX reports error at insert action: " . 
+                        $this->stringWithoutCredential("FX reports error at insert action: " .
                             "code={$result['errorCode']}, url={$result['URL']}"));
                     $this->errorMessageStore(
-                        $this->stringWithoutCredential("FX reports error at insert action: " . 
+                        $this->stringWithoutCredential("FX reports error at insert action: " .
                             "code={$result['errorCode']}, url={$result['URL']}"));
                     return false;
                 }
@@ -163,7 +163,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
 
         if ($result['errorCode'] != 0 && $result['errorCode'] != 401) {
             $this->errorMessageStore(
-                $this->stringWithoutCredential("FX reports error at find action: " . 
+                $this->stringWithoutCredential("FX reports error at find action: " .
                     "code={$result['errorCode']}, url={$result['URL']}"));
             return false;
         } else {
@@ -194,7 +194,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
         $targetClients = array();
         if ($result['errorCode'] != 0 && $result['errorCode'] != 401) {
             $this->errorMessageStore(
-                $this->stringWithoutCredential("FX reports error at find action: " . 
+                $this->stringWithoutCredential("FX reports error at find action: " .
                     "code={$result['errorCode']}, url={$result['URL']}"));
         } else {
             if ($result['foundCount'] > 0) {
@@ -219,7 +219,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
             $result = $this->fx->DoFxAction('perform_find', TRUE, TRUE, 'full');
             if ($result['errorCode'] != 0 && $result['errorCode'] != 401) {
                 $this->errorMessageStore(
-                    $this->stringWithoutCredential("FX reports error at find action: " . 
+                    $this->stringWithoutCredential("FX reports error at find action: " .
                         "code={$result['errorCode']}, url={$result['URL']}"));
             } else {
                 if ($result['foundCount'] > 0) {
@@ -242,7 +242,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
         $targetClients = array();
         if ($result['errorCode'] != 0 && $result['errorCode'] != 401) {
             $this->errorMessageStore(
-                $this->stringWithoutCredential("FX reports error at find action: " . 
+                $this->stringWithoutCredential("FX reports error at find action: " .
                     "code={$result['errorCode']}, url={$result['URL']}"));
             return false;
         } else {
@@ -262,7 +262,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                     $result = $this->fx->DoFxAction('new', TRUE, TRUE, 'full');
                     if (!is_array($result)) {
                         $this->errorMessageStore(
-                            $this->stringWithoutCredential("FX reports error at insert action: " . 
+                            $this->stringWithoutCredential("FX reports error at insert action: " .
                                 "code={$result['errorCode']}, url={$result['URL']}"));
                         return false;
                     }
@@ -284,7 +284,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
         $targetClients = array();
         if ($result['errorCode'] != 0 && $result['errorCode'] != 401) {
             $this->errorMessageStore(
-                $this->stringWithoutCredential("FX reports error at find action: " . 
+                $this->stringWithoutCredential("FX reports error at find action: " .
                     "code={$result['errorCode']}, url={$result['URL']}"));
             return false;
         } else {
@@ -350,7 +350,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                 require_once($path);
             } else {
                 // If FX.php isn't installed in valid directories, it shows error message and finishes.
-                throw new Exception('Data Access Class "FileMaker_FX" of INTER-Mediator requires ' . 
+                throw new Exception('Data Access Class "FileMaker_FX" of INTER-Mediator requires ' .
                     basename($fxFile) . ' on any right directory.');
             }
         }
@@ -476,6 +476,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                     $useOrOperation = true;
                 } else {
                     if (isset($condition['operator'])) {
+                        $condition = $this->normalizedCondition($condition);
                         if (!$this->isPossibleOperator($condition['operator'])) {
                             throw new Exception("Invalid Operator.: {$condition['operator']}");
                         }
@@ -496,6 +497,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                         $useOrOperation = true;
                     } else {
                         if (isset($condition['operator'])) {
+                            $condition = $this->normalizedCondition($condition);
                             if (!$this->isPossibleOperator($condition['operator'])) {
                                 throw new Exception("Invalid Operator.: {$condition['operator']}");
                             }
@@ -701,7 +703,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
         } else {
             $queryString .= $currentSort . $currentSearch . '&-findall';
         }
-        
+
         $this->queriedEntity = $this->fx->layout;
         $this->queriedCondition = $queryString;
 
@@ -710,7 +712,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
         $keyField = isset($context['key']) ? $context['key'] : $this->getDefaultKey();
         try {
             $ch = curl_init();
-            curl_setopt($ch, CURLOPT_URL, 
+            curl_setopt($ch, CURLOPT_URL,
                 $this->fx->urlScheme . '://' . $this->fx->dataServer . $this->fx->dataPortSuffix . '/fmi/xml/fmresultset.xml');
             curl_setopt($ch, CURLOPT_USERPWD, $this->dbSettings->getAccessUser() . ':' . $this->dbSettings->getAccessPassword());
             curl_setopt($ch, CURLOPT_POST, true);
@@ -775,7 +777,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                             break;
                         }
                     }
-                    
+
                     $relatedsetArray = array();
                     if (isset($record['relatedset'])) {
                         if (isset($record['relatedset']['record'])) {
@@ -822,7 +824,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                             }
                         }
                     }
-                    
+
                     foreach ($relatedsetArray as $j => $relatedset) {
                         $dataArray = $dataArray + array($j => $relatedset);
                     }
@@ -846,12 +848,12 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
 
         $errorCode = intval($data['error']['@attributes']['code']);
         if ($errorCode != 0 && $errorCode != 401) {
-            $this->logger->setErrorMessage('INTER-Mediator reports error at find action: ' . 
+            $this->logger->setErrorMessage('INTER-Mediator reports error at find action: ' .
                 'errorcode=' . $errorCode . ', querystring=' . $queryString);
             return null;
         }
         $this->logger->setDebugMessage($queryString);
-        
+
         if (!$usePortal) {
             $this->mainTableCount = intval($data['resultset']['@attributes']['count']);
             $this->mainTableTotalCount = intval($data['datasource']['@attributes']['total-count']);
@@ -1915,7 +1917,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
     public function normalizedCondition($condition)
     {
         /* for FileMaker Server */
-        if (($condition['field'] == "-recid" && $condition['operator'] == 'undefined') 
+        if (($condition['field'] == '-recid' && $condition['operator'] == 'undefined')
                  || ($condition['operator'] == '=')) {
             return array(
                 'field' => $condition['field'],
@@ -2011,7 +2013,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
         }
         return $recordSet;
     }
-    
+
     function authSupportGetSalt($username)
     {
         // TODO: Implement authSupportGetSalt() method.

--- a/INTER-Mediator-UnitTest/DB_FMS_Test_Common.php
+++ b/INTER-Mediator-UnitTest/DB_FMS_Test_Common.php
@@ -22,6 +22,24 @@ class DB_FMS_Test_Common extends PHPUnit_Framework_TestCase
         date_default_timezone_set('Asia/Tokyo');
     }
 
+    public function testIsPossibleOperator()
+    {
+        $this->dbProxySetupForAccess("person_layout", 1);
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('eq'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('cn'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('bw'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('ew'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('gt'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('gte'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('gte'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('lt'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('lte'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('neq'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('and'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('or'));
+        $this->assertFalse($this->db_proxy->dbClass->isPossibleOperator('='));
+    }
+
     public function testQuery1_singleRecord()
     {
         $this->dbProxySetupForAccess("person_layout", 1);
@@ -43,7 +61,7 @@ class DB_FMS_Test_Common extends PHPUnit_Framework_TestCase
         $this->assertTrue($recordCount == 3, "This table contanins 3 records");
         $this->assertTrue($result[2]["name"] === 'Anyone', "Field value is not same as the definition.");
         $this->assertTrue($result[2]["id"] == 3, "Field value is not same as the definition.");
-        
+
         //        var_export($this->db_proxy->logger->getAllErrorMessages());
         //        var_export($this->db_proxy->logger->getDebugMessage());
     }
@@ -57,7 +75,7 @@ class DB_FMS_Test_Common extends PHPUnit_Framework_TestCase
         $createdRecord = $this->db_proxy->updatedRecord();
         $this->assertTrue($createdRecord != null, "Created record should be exists.");
         $this->assertTrue(count($createdRecord) == 1, "It should be just one record.");
-        
+
         $this->dbProxySetupForAccess("person_layout", 1000000);
         $this->db_proxy->requireUpdatedRecord(true);
         $newKeyValue = $this->db_proxy->newToDB("person_layout", true);
@@ -65,7 +83,7 @@ class DB_FMS_Test_Common extends PHPUnit_Framework_TestCase
         $createdRecord = $this->db_proxy->updatedRecord();
         $this->assertTrue($createdRecord != null, "Created record should be exists.");
         $this->assertTrue(count($createdRecord) == 1, "It should be just one record.");
-        
+
         $nameValue = "unknown, oh mygod!";
         $addressValue = "anyplace, who knows!";
         $this->dbProxySetupForAccess("person_layout", 1000000);
@@ -81,7 +99,7 @@ class DB_FMS_Test_Common extends PHPUnit_Framework_TestCase
         $this->assertTrue(count($createdRecord) == 1, "It should be just one record.");
         $this->assertTrue($createdRecord[0]["name"] === $nameValue, "Field value is not same as the definition.");
         $this->assertTrue($createdRecord[0]["address"] === $addressValue, "Field value is not same as the definition.");
-        
+
         $this->dbProxySetupForAccess("person_layout", 1000000);
         $this->db_proxy->dbSettings->addExtraCriteria("id", "=", $newKeyValue);
         $result = $this->db_proxy->getFromDB("person_layout");
@@ -89,10 +107,10 @@ class DB_FMS_Test_Common extends PHPUnit_Framework_TestCase
         $this->assertTrue(count($result) == 1, "It should be just one record.");
         $this->assertTrue($result[0]["name"] === $nameValue, "Field value is not same as the definition.");
         $this->assertTrue($result[0]["address"] === $addressValue, "Field value is not same as the definition.");
-        
+
         //        var_export($this->db_proxy->logger->getAllErrorMessages());
         //        var_export($this->db_proxy->logger->getDebugMessage());
-        
+
     }
 
     /**

--- a/INTER-Mediator-UnitTest/DB_FMS_Test_Common.php
+++ b/INTER-Mediator-UnitTest/DB_FMS_Test_Common.php
@@ -37,7 +37,22 @@ class DB_FMS_Test_Common extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('neq'));
         $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('and'));
         $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('or'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('AND'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOperator('OR'));
         $this->assertFalse($this->db_proxy->dbClass->isPossibleOperator('='));
+    }
+
+    public function testIsPossibleOrderSpecifier()
+    {
+        $this->dbProxySetupForAccess("person_layout", 1);
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOrderSpecifier('ascend'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOrderSpecifier('descend'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOrderSpecifier('asc'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOrderSpecifier('desc'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOrderSpecifier('ASCEND'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOrderSpecifier('DESCEND'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOrderSpecifier('ASC'));
+        $this->assertTrue($this->db_proxy->dbClass->isPossibleOrderSpecifier('DESC'));
     }
 
     public function testQuery1_singleRecord()

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -8,9 +8,11 @@ Change Log will be supplied by English only.
 Latest changes might exist on the GitHub repository. Please check: https://github.com/INTER-Mediator/INTER-Mediator.
 Also the Migration Guide (Japanese) might be informative: http://inter-mediator.info/ja/migration.html.
 
-Ver.5.1 (in development)
+Ver.5.2 (in development)
 - [BUG FIX] The definition file editor supports the 'soft-delete' key, and also the field which
   cant contain ether boolean or string value appropriately.
+- [BUG FIX] Fix an error when the value of 'operator' key in 'query' key is '=' in a definition 
+  file using FileMaker Server.
 
 Ver.5.1 (May 22, 2015)
 - Support uploading a file to FileMaker's container field when using FileMaker Server 13 or later.


### PR DESCRIPTION
Fixed the related issue of INTER-Mediator e-Learing course for FileMaker Server users.