### PR TITLE
Handle some operators of conditions as valid when using FileMaker Server

### DIFF
--- a/INTER-Mediator-UnitTest/DB_FMS_Test_Common.php
+++ b/INTER-Mediator-UnitTest/DB_FMS_Test_Common.php
@@ -55,6 +55,55 @@ class DB_FMS_Test_Common extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->db_proxy->dbClass->isPossibleOrderSpecifier('DESC'));
     }
 
+    public function testNormalizedCondition()
+    {
+        $this->dbProxySetupForAccess("person_layout", 1);
+
+        $condition = array(
+            'field' => 'f1',
+            'operator' => '=',
+            'value' => 'test',
+        );
+        $expected = array(
+            'field' => 'f1',
+            'operator' => 'eq',
+            'value' => 'test',
+        );
+        $this->assertEquals($expected, $this->db_proxy->dbClass->normalizedCondition($condition));
+
+        $condition['operator'] = '!=';
+        $expected['operator'] = 'neq';
+        $this->assertEquals($expected, $this->db_proxy->dbClass->normalizedCondition($condition));
+
+        $condition['operator'] = '<';
+        $expected['operator'] = 'lt';
+        $this->assertEquals($expected, $this->db_proxy->dbClass->normalizedCondition($condition));
+
+        $condition['operator'] = '<=';
+        $expected['operator'] = 'lte';
+        $this->assertEquals($expected, $this->db_proxy->dbClass->normalizedCondition($condition));
+
+        $condition['operator'] = '>';
+        $expected['operator'] = 'gt';
+        $this->assertEquals($expected, $this->db_proxy->dbClass->normalizedCondition($condition));
+
+        $condition['operator'] = '>=';
+        $expected['operator'] = 'gte';
+        $this->assertEquals($expected, $this->db_proxy->dbClass->normalizedCondition($condition));
+
+        $condition['operator'] = 'match*';
+        $expected['operator'] = 'bw';
+        $this->assertEquals($expected, $this->db_proxy->dbClass->normalizedCondition($condition));
+
+        $condition['operator'] = '*match';
+        $expected['operator'] = 'ew';
+        $this->assertEquals($expected, $this->db_proxy->dbClass->normalizedCondition($condition));
+
+        $condition['operator'] = '*match*';
+        $expected['operator'] = 'cn';
+        $this->assertEquals($expected, $this->db_proxy->dbClass->normalizedCondition($condition));
+    }
+
     public function testQuery1_singleRecord()
     {
         $this->dbProxySetupForAccess("person_layout", 1);

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -9,6 +9,8 @@ Latest changes might exist on the GitHub repository. Please check: https://githu
 Also the Migration Guide (Japanese) might be informative: http://inter-mediator.info/ja/migration.html.
 
 Ver.5.2 (in development)
+- Handle some operators of conditions ('!=', '>', '>=', '<', '<=') as valid when using FileMaker 
+  Server.
 - [BUG FIX] The definition file editor supports the 'soft-delete' key, and also the field which
   cant contain ether boolean or string value appropriately.
 - [BUG FIX] Fix an error when the value of 'operator' key in 'query' key is '=' in a definition 


### PR DESCRIPTION
Handled some operators of conditions ('!=', '>', '>=', '<', '<=') as valid when using FileMaker Server.