### PR TITLE
Fix 'inline' and 'end-of-sibling' key options of validation

### DIFF
--- a/INTER-Mediator-Element.js
+++ b/INTER-Mediator-Element.js
@@ -178,11 +178,10 @@ var IMLibElement = {
                 }
             }
         }
-        if (nodeTag == "INPUT" || nodeTag == "SELECT" || nodeTag == "TEXTAREA")   {
+        if (nodeTag === "INPUT" || nodeTag === "SELECT" || nodeTag === "TEXTAREA")   {
             INTERMediatorLib.addEvent(element, "blur", function (e) {
                 //console.log("Event Dispatcher: blur");
-                var idValue = element.id;
-                IMLibUI.valueChange(idValue, true);
+                IMLibUI.validation(element);
             });
 
         }

--- a/INTER-Mediator-Lib.js
+++ b/INTER-Mediator-Lib.js
@@ -780,7 +780,7 @@ var INTERMediatorLib = {
 
         function checkNode(target) {
             var value, i, items;
-            if (target.nodeType != 1) {
+            if (target === undefined || target.nodeType !== 1) {
                 return;
             }
             value = INTERMediatorLib.getClassAttributeFromNode(target);
@@ -824,7 +824,7 @@ var INTERMediatorLib = {
 
         function checkNode(target) {
             var className, i;
-            if (target.nodeType != 1) {
+            if (target === undefined || target.nodeType !== 1) {
                 return;
             }
             className = INTERMediatorLib.getClassAttributeFromNode(target);
@@ -845,7 +845,7 @@ var INTERMediatorLib = {
 
         function checkNode(target) {
             var nodeId, i;
-            if (target.nodeType != 1) {
+            if (target === undefined || target.nodeType !== 1) {
                 return;
             }
             nodeId = target.getAttribute("id");

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -17,6 +17,8 @@ Ver.5.2 (in development)
 - [BUG FIX] Fix an error when the value of 'operator' key in 'query' key is '=' in a definition 
   file using FileMaker Server.
 - [BUG FIX] Calculation bug fixed. In case of multiple uses of a calculated property.
+- [BUG FIX] Fix 'inline' and 'end-of-sibling' key options of validation. The affected version is 
+  5.1 only.
 
 Ver.5.1 (May 22, 2015)
 - Support uploading a file to FileMaker's container field when using FileMaker Server 13 or later.


### PR DESCRIPTION
Removed validationOnly parameter of valueChange(), and changed validation() as public method to fix 'inline' and 'end-of-sibling' key options of validation (the affected version is 5.1 only).