### PR TITLE
PDO Supports Record Dupulication

### DIFF
--- a/DB_PDO.php
+++ b/DB_PDO.php
@@ -1119,28 +1119,104 @@ class DB_PDO extends DB_AuthCommon implements DB_Access_Interface, DB_Interface_
     private function copyRecords($tableInfo, $queryClause, $assocField, $assocValue)
     {
         $tableName = $tableInfo["table"] ? $tableInfo["table"] : $tableInfo["name"];
-        $sql = "show columns from {$tableName}";
-        $this->logger->setDebugMessage($sql);
-        $result = $this->link->query($sql);
-        if (!$result) {
-            $this->errorMessageStore('Show Columns Error:' . $sql);
-            return false;
-        }
-        $fieldArray = array();
-        $listArray = array();
-        foreach ($result->fetchAll(PDO::FETCH_ASSOC) as $row) {
-            if ($tableInfo['key'] === $row['Field'] || ! is_null($row['Default'])) {
-
-            } else if ($assocField === $row['Field']) {
-                $fieldArray[] = $this->quotedFieldName($row['Field']);
-                $listArray[] = $this->link->quote($assocValue);
-            } else {
-                $fieldArray[] = $this->quotedFieldName($row['Field']);
-                $listArray[] = $this->quotedFieldName($row['Field']);
+        if (strpos($this->dbSettings->getDbSpecDSN(), 'mysql:') === 0) {
+            $sql = "show columns from {$tableName}";
+            $this->logger->setDebugMessage($sql);
+            $result = $this->link->query($sql);
+            if (!$result) {
+                $this->errorMessageStore('Show Columns Error:' . $sql);
+                return false;
             }
+            $fieldArray = array();
+            $listArray = array();
+            foreach ($result->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                if ($tableInfo['key'] === $row['Field'] || !is_null($row['Default'])) {
+
+                } else if ($assocField === $row['Field']) {
+                    $fieldArray[] = $this->quotedFieldName($row['Field']);
+                    $listArray[] = $this->link->quote($assocValue);
+                } else {
+                    $fieldArray[] = $this->quotedFieldName($row['Field']);
+                    $listArray[] = $this->quotedFieldName($row['Field']);
+                }
+            }
+            $fieldList = implode(',', $fieldArray);
+            $listList = implode(',', $listArray);
+        } else if (strpos($this->dbSettings->getDbSpecDSN(), 'pgsql:') === 0) {
+            /*
+# select table_catalog,table_schema,table_name,column_name,column_default from information_schema.columns where table_name='person';
+ table_catalog | table_schema | table_name | column_name |                column_default
+---------------+--------------+------------+-------------+----------------------------------------------
+ test_db       | im_sample    | person     | id          | nextval('im_sample.person_id_seq'::regclass)
+ test_db       | im_sample    | person     | name        |
+ test_db       | im_sample    | person     | address     |
+ test_db       | im_sample    | person     | mail        |
+ test_db       | im_sample    | person     | category    |
+ test_db       | im_sample    | person     | checking    |
+ test_db       | im_sample    | person     | location    |
+ test_db       | im_sample    | person     | memo        |
+             */
+            $sql = "SELECT column_name, column_default FROM information_schema.columns "
+                . "WHERE table_name=" . $this->link->quote($tableName);
+            $this->logger->setDebugMessage($sql);
+            $result = $this->link->query($sql);
+            if (!$result) {
+                $this->errorMessageStore('Show Columns Error:' . $sql);
+                return false;
+            }
+            $fieldArray = array();
+            $listArray = array();
+            foreach ($result->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                if ($tableInfo['key'] === $row['column_name'] || !is_null($row['column_default'])) {
+
+                } else if ($assocField === $row['column_name']) {
+                    $fieldArray[] = $this->quotedFieldName($row['column_name']);
+                    $listArray[] = $this->link->quote($assocValue);
+                } else {
+                    $fieldArray[] = $this->quotedFieldName($row['column_name']);
+                    $listArray[] = $this->quotedFieldName($row['column_name']);
+                }
+            }
+            $fieldList = implode(',', $fieldArray);
+            $listList = implode(',', $listArray);
+        } else if (strpos($this->dbSettings->getDbSpecDSN(), 'sqlite:') === 0) {
+            /*
+            sqlite> PRAGMA table_info(person);
+            cid         name        type        notnull     dflt_value  pk
+            ----------  ----------  ----------  ----------  ----------  ----------
+            0           id          INTEGER     0                       1
+            1           name        TEXT        0                       0
+            2           address     TEXT        0                       0
+            3           mail        TEXT        0                       0
+            4           category    INTEGER     0                       0
+            5           checking    INTEGER     0                       0
+            6           location    INTEGER     0                       0
+            7           memo        TEXT        0                       0
+             */
+            $sql = "PRAGMA table_info({$tableName})";
+            $this->logger->setDebugMessage($sql);
+            $result = $this->link->query($sql);
+            if (!$result) {
+                $this->errorMessageStore('PRAGMA table_info Error:' . $sql);
+                return false;
+            }
+            $fieldArray = array();
+            $listArray = array();
+            foreach ($result->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                if ($tableInfo['key'] === $row['name'] || !is_null($row['dflt_value'])) {
+
+                } else if ($assocField === $row['name']) {
+                    $fieldArray[] = $this->quotedFieldName($row['name']);
+                    $listArray[] = $this->link->quote($assocValue);
+                } else {
+                    $fieldArray[] = $this->quotedFieldName($row['name']);
+                    $listArray[] = $this->quotedFieldName($row['name']);
+                }
+            }
+            $fieldList = implode(',', $fieldArray);
+            $listList = implode(',', $listArray);
+
         }
-        $fieldList = implode(',', $fieldArray);
-        $listList = implode(',', $listArray);
         //======
         $sql = "INSERT INTO {$tableName} ({$fieldList}) SELECT {$listList} FROM {$tableName} WHERE {$queryClause}";
         $this->logger->setDebugMessage($sql);

--- a/DB_PDO.php
+++ b/DB_PDO.php
@@ -1157,11 +1157,11 @@ class DB_PDO extends DB_AuthCommon implements DB_Access_Interface, DB_Interface_
  test_db       | im_sample    | person     | memo        |
              */
             if (strpos($tableName, ".") !== false) {
-                $tableName = substr($tableName, strpos($tableName, ".") + 1);
+                $tName = substr($tableName, strpos($tableName, ".") + 1);
                 $schemaName = substr($tableName, 0, strpos($tableName, "."));
                 $sql = "SELECT column_name, column_default FROM information_schema.columns "
                     . "WHERE table_schema=" . $this->link->quote($schemaName)
-                    . " AND table_name=" . $this->link->quote($tableName);
+                    . " AND table_name=" . $this->link->quote($tName);
             } else {
                 $sql = "SELECT column_name, column_default FROM information_schema.columns "
                     . "WHERE table_name=" . $this->link->quote($tableName);

--- a/DB_PDO.php
+++ b/DB_PDO.php
@@ -1156,8 +1156,16 @@ class DB_PDO extends DB_AuthCommon implements DB_Access_Interface, DB_Interface_
  test_db       | im_sample    | person     | location    |
  test_db       | im_sample    | person     | memo        |
              */
-            $sql = "SELECT column_name, column_default FROM information_schema.columns "
-                . "WHERE table_name=" . $this->link->quote($tableName);
+            if (strpos($tableName, ".") !== false) {
+                $tableName = substr($tableName, strpos($tableName, ".") + 1);
+                $schemaName = substr($tableName, 0, strpos($tableName, "."));
+                $sql = "SELECT column_name, column_default FROM information_schema.columns "
+                    . "WHERE table_schema=" . $this->link->quote($schemaName)
+                    . " AND table_name=" . $this->link->quote($tableName);
+            } else {
+                $sql = "SELECT column_name, column_default FROM information_schema.columns "
+                    . "WHERE table_name=" . $this->link->quote($tableName);
+            }
             $this->logger->setDebugMessage($sql);
             $result = $this->link->query($sql);
             if (!$result) {

--- a/DB_PDO.php
+++ b/DB_PDO.php
@@ -1118,7 +1118,7 @@ class DB_PDO extends DB_AuthCommon implements DB_Access_Interface, DB_Interface_
 
     private function copyRecords($tableInfo, $queryClause, $assocField, $assocValue)
     {
-        $tableName = $tableInfo["table"] ? $tableInfo["table"] : $tableInfo["name"];
+        $tableName = isset($tableInfo["table"]) ? $tableInfo["table"] : $tableInfo["name"];
         if (strpos($this->dbSettings->getDbSpecDSN(), 'mysql:') === 0) {
             $sql = "show columns from {$tableName}";
             $this->logger->setDebugMessage($sql);

--- a/INTER-Mediator-UnitTest/DB_PDO-MySQL_Test.php
+++ b/INTER-Mediator-UnitTest/DB_PDO-MySQL_Test.php
@@ -19,7 +19,7 @@ class DB_PDO_MySQL_Test extends DB_PDO_Test_Common
 
     }
 
-    function dbProxySetupForAccess($contextName, $maxRecord)
+    function dbProxySetupForAccess($contextName, $maxRecord, $subContextName = null)
     {
         $this->schemaName = "";
         $contexts = array(
@@ -27,11 +27,24 @@ class DB_PDO_MySQL_Test extends DB_PDO_Test_Common
                 'records' => $maxRecord,
                 'name' => $contextName,
                 'key' => 'id',
+                'repeat-control' => is_null($subContextName) ? 'copy' : "copy-{$subContextName}",
                 'sort' => array(
-                    array('field'=>'id','direction'=>'asc'),
+                    array('field' => 'id', 'direction' => 'asc'),
                 ),
             )
         );
+        if (!is_null($subContextName)) {
+            $contexts[] = array(
+                'records' => $maxRecord,
+                'name' => $subContextName,
+                'key' => 'id',
+                'relation' => array(
+                    "foreign-key" => "{$contextName}_id",
+                    "join-field" => "id",
+                    "operator" => "=",
+                ),
+            );
+        }
         $options = null;
         $dbSettings = array(
             'db-class' => 'PDO',
@@ -47,16 +60,16 @@ class DB_PDO_MySQL_Test extends DB_PDO_Test_Common
     {
         $this->db_proxy = new DB_Proxy(true);
         $this->db_proxy->initialize(array(
-                array(
-                    'records' => 1,
-                    'paging' => true,
-                    'name' => 'person',
-                    'key' => 'id',
-                    'query' => array( /* array( 'field'=>'id', 'value'=>'5', 'operator'=>'eq' ),*/),
-                    'sort' => array(array('field' => 'id', 'direction' => 'asc'),),
-                    'sequence' => 'im_sample.serial',
-                )
-            ),
+            array(
+                'records' => 1,
+                'paging' => true,
+                'name' => 'person',
+                'key' => 'id',
+                'query' => array( /* array( 'field'=>'id', 'value'=>'5', 'operator'=>'eq' ),*/),
+                'sort' => array(array('field' => 'id', 'direction' => 'asc'),),
+                'sequence' => 'im_sample.serial',
+            )
+        ),
             array(
                 'authentication' => array( // table only, for all operations
                     'user' => array('user1'), // Itemize permitted users

--- a/INTER-Mediator-UnitTest/DB_PDO-MySQL_Test.php
+++ b/INTER-Mediator-UnitTest/DB_PDO-MySQL_Test.php
@@ -26,6 +26,8 @@ class DB_PDO_MySQL_Test extends DB_PDO_Test_Common
             array(
                 'records' => $maxRecord,
                 'name' => $contextName,
+                'view' => $contextName,
+                'table' => $contextName,
                 'key' => 'id',
                 'repeat-control' => is_null($subContextName) ? 'copy' : "copy-{$subContextName}",
                 'sort' => array(
@@ -37,6 +39,8 @@ class DB_PDO_MySQL_Test extends DB_PDO_Test_Common
             $contexts[] = array(
                 'records' => $maxRecord,
                 'name' => $subContextName,
+                'view' => $subContextName,
+                'table' => $subContextName,
                 'key' => 'id',
                 'relation' => array(
                     "foreign-key" => "{$contextName}_id",

--- a/INTER-Mediator-UnitTest/DB_PDO-PostgreSQL_Test.php
+++ b/INTER-Mediator-UnitTest/DB_PDO-PostgreSQL_Test.php
@@ -19,7 +19,7 @@ class DB_PDO_PostgreSQL_Test extends DB_PDO_Test_Common
 
     }
 
-    function dbProxySetupForAccess($contextName, $maxRecord)
+    function dbProxySetupForAccess($contextName, $maxRecord, $subContextName = null)
     {
         $this->schemaName = "im_sample.";
         $seqName = ($contextName == "person") ? "im_sample.person_id_seq" : "im_sample.serial";
@@ -30,12 +30,25 @@ class DB_PDO_PostgreSQL_Test extends DB_PDO_Test_Common
                 'view' => "{$this->schemaName}{$contextName}",
                 'table' => "{$this->schemaName}{$contextName}",
                 'key' => 'id',
+                'repeat-control' => is_null($subContextName) ? 'copy' : "copy-{$subContextName}",
                 'sort' => array(
                     array('field' => 'id', 'direction' => 'asc'),
                 ),
                 'sequence' => $seqName,
             )
         );
+        if (!is_null($subContextName)) {
+            $contexts[] = array(
+                'records' => $maxRecord,
+                'name' => $subContextName,
+                'key' => 'id',
+                'relation' => array(
+                    "foreign-key" => "{$contextName}_id",
+                    "join-field" => "id",
+                    "operator" => "=",
+                ),
+            );
+        }
         $options = null;
         $dbSettings = array(
             'db-class' => 'PDO',

--- a/INTER-Mediator-UnitTest/DB_PDO-SQLite_Test.php
+++ b/INTER-Mediator-UnitTest/DB_PDO-SQLite_Test.php
@@ -13,7 +13,7 @@ class DB_PDO_SQLite_Test extends DB_PDO_Test_Common
 
     }
 
-    function dbProxySetupForAccess($contextName, $maxRecord)
+    function dbProxySetupForAccess($contextName, $maxRecord, $subContextName = null)
     {
         $this->schemaName = "";
         $contexts = array(
@@ -23,11 +23,24 @@ class DB_PDO_SQLite_Test extends DB_PDO_Test_Common
                 'view' => "{$this->schemaName}{$contextName}",
                 'table' => "{$this->schemaName}{$contextName}",
                 'key' => 'id',
+                'repeat-control' => is_null($subContextName) ? 'copy' : "copy-{$subContextName}",
                 'sort' => array(
                     array('field'=>'id','direction'=>'asc'),
                 ),
             )
         );
+        if (!is_null($subContextName)) {
+            $contexts[] = array(
+                'records' => $maxRecord,
+                'name' => $subContextName,
+                'key' => 'id',
+                'relation' => array(
+                    "foreign-key" => "{$contextName}_id",
+                    "join-field" => "id",
+                    "operator" => "=",
+                ),
+            );
+        }
         $options = null;
         $dbSettings = array(
             'db-class' => 'PDO',

--- a/INTER-Mediator-UnitTest/DB_PDO_Test_Common.php
+++ b/INTER-Mediator-UnitTest/DB_PDO_Test_Common.php
@@ -151,7 +151,8 @@ abstract class DB_PDO_Test_Common extends PHPUnit_Framework_TestCase
         $result = $this->db_proxy->getFromDB("contact");
         $recordCountContactAfter = $this->db_proxy->countQueryResult("contact");
         $this->assertTrue($recordCountContact + $recordCountIncrease == $recordCountContactAfter,
-            "After copy a record, the count of associated records should increase one or more.");
+            "After copy a record, the count of associated records should increase one or more."
+            . "[$recordCountContact, $recordCountIncrease, $recordCountContactAfter]");
 
     }
 

--- a/INTER-Mediator-UnitTest/DB_PDO_Test_Common.php
+++ b/INTER-Mediator-UnitTest/DB_PDO_Test_Common.php
@@ -139,8 +139,8 @@ abstract class DB_PDO_Test_Common extends PHPUnit_Framework_TestCase
         $this->db_proxy->dbSettings->addAssociated("contact", "person_id", $parentId);
         $this->db_proxy->copyInDB("person");
 
-        var_export($this->db_proxy->logger->getErrorMessages());
-        var_export($this->db_proxy->logger->getDebugMessages());
+//        var_export($this->db_proxy->logger->getErrorMessages());
+//        var_export($this->db_proxy->logger->getDebugMessages());
 
         $this->dbProxySetupForAccess("person", 1000000);
         $result = $this->db_proxy->getFromDB("person");

--- a/INTER-Mediator-UnitTest/DB_PDO_Test_Common.php
+++ b/INTER-Mediator-UnitTest/DB_PDO_Test_Common.php
@@ -136,6 +136,7 @@ abstract class DB_PDO_Test_Common extends PHPUnit_Framework_TestCase
 
         $this->dbProxySetupForAccess("person", 1000000, "contact");
         $this->db_proxy->dbSettings->addExtraCriteria("id", "=", $parentId);
+        $this->db_proxy->dbSettings->addAssociated("contact", "person_id", $parentId);
         $this->db_proxy->copyInDB("person");
 
         var_export($this->db_proxy->logger->getErrorMessages());

--- a/INTER-Mediator-UnitTest/DB_PDO_Test_Common.php
+++ b/INTER-Mediator-UnitTest/DB_PDO_Test_Common.php
@@ -107,8 +107,8 @@ abstract class DB_PDO_Test_Common extends PHPUnit_Framework_TestCase
         $this->db_proxy->dbSettings->addExtraCriteria("id", "=", $parentId);
         $this->db_proxy->copyInDB("person");
 
-        var_export($this->db_proxy->logger->getErrorMessages());
-        var_export($this->db_proxy->logger->getDebugMessages());
+//        var_export($this->db_proxy->logger->getErrorMessages());
+//        var_export($this->db_proxy->logger->getDebugMessages());
 
         $this->dbProxySetupForAccess("person", 1000000, "contact");
         $result = $this->db_proxy->getFromDB("person");
@@ -137,6 +137,9 @@ abstract class DB_PDO_Test_Common extends PHPUnit_Framework_TestCase
         $this->dbProxySetupForAccess("person", 1000000, "contact");
         $this->db_proxy->dbSettings->addExtraCriteria("id", "=", $parentId);
         $this->db_proxy->copyInDB("person");
+
+        var_export($this->db_proxy->logger->getErrorMessages());
+        var_export($this->db_proxy->logger->getDebugMessages());
 
         $this->dbProxySetupForAccess("person", 1000000);
         $result = $this->db_proxy->getFromDB("person");

--- a/Samples/Sample_form/include_MySQL.php
+++ b/Samples/Sample_form/include_MySQL.php
@@ -114,5 +114,5 @@ IM_Entry(array(
     array(
         'db-class' => 'PDO',
     ),
-    false);
+    2);
 ?>

--- a/Samples/Sample_form/include_PostgreSQL.php
+++ b/Samples/Sample_form/include_PostgreSQL.php
@@ -20,7 +20,7 @@ IM_Entry(
             'key' => 'id',
             'query' => array( /* array( 'field'=>'id', 'value'=>'5', 'operator'=>'eq' ),*/),
             'sort' => array(array('field' => 'id', 'direction' => 'asc'),),
-            'repeat-control' => 'insert delete',
+            'repeat-control' => 'insert delete copy-contact,history',
             'sequence' => 'im_sample.person_id_seq',
         ),
         array(
@@ -31,7 +31,7 @@ IM_Entry(
             'relation' => array(
                 array('foreign-key' => 'person_id', 'join-field' => 'id', 'operator' => '=')
             ),
-            'repeat-control' => 'insert delete',
+            'repeat-control' => 'insert delete copy',
             'sequence' => 'im_sample.serial',
         ),
         array(

--- a/Samples/Sample_form/include_SQLite.php
+++ b/Samples/Sample_form/include_SQLite.php
@@ -18,7 +18,7 @@ IM_Entry(
             'key' => 'id',
             'query' => array( /* array( 'field'=>'id', 'value'=>'5', 'operator'=>'eq' ),*/),
             'sort' => array(array('field' => 'id', 'direction' => 'asc'),),
-            'repeat-control' => 'insert delete',
+            'repeat-control' => 'insert delete copy-contact,history',
         ),
         array(
             'name' => 'contact',
@@ -26,7 +26,7 @@ IM_Entry(
             'relation' => array(
                 array('foreign-key' => 'person_id', 'join-field' => 'id', 'operator' => '=')
             ),
-            'repeat-control' => 'insert delete',
+            'repeat-control' => 'insert delete copy',
         ),
         array(
             'name' => 'contact_way',

--- a/params.php
+++ b/params.php
@@ -16,7 +16,7 @@ $dbPassword = 'password';
 
 /* DB_FileMaker_FX aware below:
  */
-$dbServer = '127.0.0.1';
+$dbServer = '10.0.1.21';
 $dbPort = '80';
 $dbDataType = 'FMPro12';
 $dbDatabase = 'TestDB';


### PR DESCRIPTION
MySQL already supported the record duplication. PostgreSQL and SQLite do too. Moreover the test case of these three db engines are presented.