### PR TITLE
Update deploy.sh to enable mod_headers in INTER-Mediator Server VM

### DIFF
--- a/dist-docs/vm-for-trial/deploy.sh
+++ b/dist-docs/vm-for-trial/deploy.sh
@@ -20,6 +20,7 @@ IMSAMPLE="${IMROOT}/Samples"
 IMUNITTEST="${IMROOT}/INTER-Mediator-UnitTest"
 IMDISTDOC="${IMROOT}/dist-docs"
 IMVMROOT="${IMROOT}/dist-docs/vm-for-trial"
+APACHEOPTCONF="/etc/apache2/sites-enabled/inter-mediator-server.conf"
 SMBCONF="/etc/samba/smb.conf"
 
 groupadd im-developer
@@ -56,6 +57,9 @@ aptitude install libfontconfig1 --assume-yes
 aptitude install phpunit --assume-yes
 aptitude install samba --assume-yes
 aptitude clean
+
+a2enmod headers
+echo "#Header add Content-Security-Policy \"default-src 'self'\"" > "${APACHEOPTCONF}"
 
 cd "${WEBROOT}"
 git clone https://github.com/INTER-Mediator/INTER-Mediator.git

--- a/dist-docs/vm-for-trial/recipe.rb
+++ b/dist-docs/vm-for-trial/recipe.rb
@@ -14,6 +14,7 @@ IMSAMPLE = "#{IMROOT}/Samples"
 IMUNITTEST = "#{IMROOT}/INTER-Mediator-UnitTest"
 IMDISTDOC = "#{IMROOT}/dist-docs"
 IMVMROOT = "#{IMROOT}/dist-docs/vm-for-trial"
+APACHEOPTCONF="/etc/apache2/sites-enabled/inter-mediator-server.conf"
 SMBCONF = "/etc/samba/smb.conf"
 
 
@@ -335,6 +336,15 @@ end
 if node[:platform] == 'ubuntu'
   execute 'aptitude clean' do
     command 'aptitude clean'
+  end
+  file "#{APACHEOPTCONF}" do
+    content '#Header add Content-Security-Policy "default-src \'self\'"'
+  end
+end
+
+if node[:platform] == 'ubuntu'
+  execute 'a2enmod headers' do
+    command 'a2enmod headers'
   end
 end
 
@@ -700,8 +710,8 @@ execute "sqlite3 /var/db/im/sample.sq3 < \"#{IMDISTDOC}/sample_schema_sqlite.txt
   command "sqlite3 /var/db/im/sample.sq3 < \"#{IMDISTDOC}/sample_schema_sqlite.txt\""
 end
 
-execute "setfacl --recursive --modify g:im-developer:rw \"#{WEBROOT}\"" do
-  command "setfacl --recursive --modify g:im-developer:rw \"#{WEBROOT}\""
+execute "setfacl --recursive --modify g:im-developer:rw,d:g:im-developer:rw \"#{WEBROOT}\"" do
+  command "setfacl --recursive --modify g:im-developer:rw,d:g:im-developer:rw \"#{WEBROOT}\""
 end
 
 execute "chown -R developer:im-developer \"#{WEBROOT}\"" do

--- a/dist-docs/vm-for-trial/spec/192.168.56.101/sample_spec.rb
+++ b/dist-docs/vm-for-trial/spec/192.168.56.101/sample_spec.rb
@@ -252,6 +252,15 @@ describe package('samba') do
   it { should be_installed }
 end
 
+describe file('/etc/apache2/mods-enabled/headers.load'), :if => os[:family] == 'ubuntu' do
+  it { should be_file }
+end
+
+describe file('/etc/apache2/sites-enabled/inter-mediator-server.conf'), :if => os[:family] == 'ubuntu' do
+  it { should be_file }
+  its(:content) { should match /#Header add Content-Security-Policy "default-src 'self'"/ }
+end
+
 describe file('/var/www/html/INTER-Mediator') do
   it { should be_directory }
 end


### PR DESCRIPTION
Enabled mod_headers in order to test CSP ("Header" directive of mod_headers is not enabled).