### PR TITLE
Fix showing an image of FileMaker's container field (Ver. 5.1)

### DIFF
--- a/INTER-Mediator-Element.js
+++ b/INTER-Mediator-Element.js
@@ -64,7 +64,7 @@ var IMLibElement = {
                     element.style[styleName] = curVal;
                 } else {
                     currentValue = element.getAttribute(curTarget);
-                    if (curVal.indexOf("/fmi/xml/cnt/") === 0) {
+                    if (curVal.indexOf("/fmi/xml/cnt/") === 0 && currentValue.indexOf("?media=") === -1) {
                         curVal = INTERMediatorOnPage.getEntryPath() + "?media=" + curVal;
                     }
                     element.setAttribute(curTarget, currentValue + curVal);
@@ -87,7 +87,7 @@ var IMLibElement = {
                     element.style[styleName] = curVal;
                 } else {
                     currentValue = element.getAttribute(curTarget);
-                    if (curVal.indexOf("/fmi/xml/cnt/") === 0) {
+                    if (curVal.indexOf("/fmi/xml/cnt/") === 0 && currentValue.indexOf("?media=") === -1) {
                         curVal = INTERMediatorOnPage.getEntryPath() + "?media=" + curVal;
                     }
                     element.setAttribute(curTarget, currentValue.replace("$", curVal));

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -64,6 +64,8 @@ Ver.5.2 (in development)
 - [BUG FIX] PDO class had a bug for authentication but it would affect in a rare case.
 - [BUG FIX] Fix inserting data including null character to the database when using FileMaker Server.
 - [BUG FIX] Post Only Mode and Validation work fine.
+- [BUG FIX] Fix showing an image of FileMaker's container field if the value of "src" attribute in 
+  the page file includes "?media=". The affected version is 5.1 only.
 
 Ver.5.1 (May 22, 2015)
 - Support uploading a file to FileMaker's container field when using FileMaker Server 13 or later.


### PR DESCRIPTION
Fixed showing an image of FileMaker's container field if the value of "src" attribute in the page file includes "?media=". The affected version is 5.1 only.