### PR TITLE
Modify the behavior of 'maxrecords' key for pagination

### DIFF
--- a/Adapter_DBServer.js
+++ b/Adapter_DBServer.js
@@ -33,13 +33,13 @@ INTERMediator_DBAdapter = {
             if (INTERMediatorOnPage.isNativeAuth || INTERMediatorOnPage.isLDAP) {
                 if (INTERMediatorOnPage.authCryptedPassword && INTERMediatorOnPage.authChallenge) {
                     authParams += "&cresponse=" + encodeURIComponent(
-                        INTERMediatorOnPage.publickey.biEncryptedString(INTERMediatorOnPage.authCryptedPassword
-                        + "\n" + INTERMediatorOnPage.authChallenge));
+                        INTERMediatorOnPage.publickey.biEncryptedString(INTERMediatorOnPage.authCryptedPassword +
+                            "\n" + INTERMediatorOnPage.authChallenge));
                     if (INTERMediator_DBAdapter.degubMessage) {
-                        INTERMediator.setDebugMessage("generate_authParams/authCryptedPassword="
-                        + INTERMediatorOnPage.authCryptedPassword);
-                        INTERMediator.setDebugMessage("generate_authParams/authChallenge="
-                        + INTERMediatorOnPage.authChallenge);
+                        INTERMediator.setDebugMessage("generate_authParams/authCryptedPassword=" +
+                            INTERMediatorOnPage.authCryptedPassword);
+                        INTERMediator.setDebugMessage("generate_authParams/authChallenge=" +
+                            INTERMediatorOnPage.authChallenge);
                     }
                 } else {
                     authParams += "&cresponse=dummy";
@@ -50,10 +50,10 @@ INTERMediator_DBAdapter = {
                 hmacValue = shaObj.getHMAC(INTERMediatorOnPage.authChallenge, "ASCII", "SHA-256", "HEX");
                 authParams += "&response=" + encodeURIComponent(hmacValue);
                 if (INTERMediator_DBAdapter.degubMessage) {
-                    INTERMediator.setDebugMessage("generate_authParams/authHashedPassword="
-                    + INTERMediatorOnPage.authHashedPassword);
-                    INTERMediator.setDebugMessage("generate_authParams/authChallenge="
-                    + INTERMediatorOnPage.authChallenge);
+                    INTERMediator.setDebugMessage("generate_authParams/authHashedPassword=" +
+                        INTERMediatorOnPage.authHashedPassword);
+                    INTERMediator.setDebugMessage("generate_authParams/authChallenge=" +
+                        INTERMediatorOnPage.authChallenge);
                 }
             } else {
                 authParams += "&response=dummy";
@@ -85,8 +85,8 @@ INTERMediator_DBAdapter = {
 
     logging_comAction: function (debugMessageNumber, appPath, accessURL, authParams) {
         INTERMediator.setDebugMessage(
-            INTERMediatorOnPage.getMessages()[debugMessageNumber]
-            + "Accessing:" + decodeURI(appPath) + ", Parameters:" + decodeURI(accessURL + authParams));
+            INTERMediatorOnPage.getMessages()[debugMessageNumber] +
+                "Accessing:" + decodeURI(appPath) + ", Parameters:" + decodeURI(accessURL + authParams));
     },
 
     logging_comResult: function (myRequest, resultCount, dbresult, requireAuth, challenge, clientid, newRecordKeyValue, changePasswordResult, mediatoken) {
@@ -98,12 +98,12 @@ INTERMediator_DBAdapter = {
                 responseTextTrancated = myRequest.responseText;
             }
             INTERMediator.setDebugMessage("myRequest.responseText=" + responseTextTrancated);
-            INTERMediator.setDebugMessage("Return: resultCount=" + resultCount
-                + ", dbresult=" + INTERMediatorLib.objectToString(dbresult) + "\n"
-                + "Return: requireAuth=" + requireAuth
-                + ", challenge=" + challenge + ", clientid=" + clientid + "\n"
-                + "Return: newRecordKeyValue=" + newRecordKeyValue
-                + ", changePasswordResult=" + changePasswordResult + ", mediatoken=" + mediatoken
+            INTERMediator.setDebugMessage("Return: resultCount=" + resultCount +
+                ", dbresult=" + INTERMediatorLib.objectToString(dbresult) + "\n" +
+                "Return: requireAuth=" + requireAuth +
+                ", challenge=" + challenge + ", clientid=" + clientid + "\n" +
+                "Return: newRecordKeyValue=" + newRecordKeyValue +
+                ", changePasswordResult=" + changePasswordResult + ", mediatoken=" + mediatoken
             );
         }
     },
@@ -192,8 +192,8 @@ INTERMediator_DBAdapter = {
 
         if (username && oldpassword) {
             INTERMediatorOnPage.authUser = username;
-            if (username != ''    // No usename and no challenge, get a challenge.
-                && (INTERMediatorOnPage.authChallenge === null || INTERMediatorOnPage.authChallenge.length < 24 )) {
+            if (username !== "" &&  // No usename and no challenge, get a challenge.
+                (INTERMediatorOnPage.authChallenge === null || INTERMediatorOnPage.authChallenge.length < 24 )) {
                 INTERMediatorOnPage.authHashedPassword = "need-hash-pls";   // Dummy Hash for getting a challenge
                 challengeResult = INTERMediator_DBAdapter.getChallenge();
                 if (!challengeResult) {
@@ -201,9 +201,9 @@ INTERMediator_DBAdapter = {
                     return false; // If it's failed to get a challenge, finish everything.
                 }
             }
-            INTERMediatorOnPage.authHashedPassword
-                = SHA1(oldpassword + INTERMediatorOnPage.authUserSalt)
-            + INTERMediatorOnPage.authUserHexSalt;
+            INTERMediatorOnPage.authHashedPassword =
+                SHA1(oldpassword + INTERMediatorOnPage.authUserSalt) +
+                INTERMediatorOnPage.authUserHexSalt;
         } else {
             INTERMediatorOnPage.retrieveAuthInfo();
         }
@@ -211,10 +211,10 @@ INTERMediator_DBAdapter = {
         try {
             result = INTERMediator_DBAdapter.server_access(params, 1029, 1030);
             if (result.newPasswordResult && result.newPasswordResult === true) {
-                INTERMediatorOnPage.authCryptedPassword
-                    = INTERMediatorOnPage.publickey.biEncryptedString(newpassword);
-                INTERMediatorOnPage.authHashedPassword
-                    = SHA1(newpassword + INTERMediatorOnPage.authUserSalt) + INTERMediatorOnPage.authUserHexSalt;
+                INTERMediatorOnPage.authCryptedPassword =
+                    INTERMediatorOnPage.publickey.biEncryptedString(newpassword);
+                INTERMediatorOnPage.authHashedPassword =
+                    SHA1(newpassword + INTERMediatorOnPage.authUserSalt) + INTERMediatorOnPage.authUserHexSalt;
                 INTERMediatorOnPage.storeCredencialsToCookie();
             }
         } catch (e) {
@@ -326,7 +326,7 @@ INTERMediator_DBAdapter = {
      This function returns recordset of retrieved.
      */
     db_query: function (args) {
-        var noError = true, i, index, params, counter, extCount, criteriaObject, sortkeyObject,
+        var noError = true, i, index, params, dbspec, counter, extCount, criteriaObject, sortkeyObject,
             returnValue, result, ix, extCountSort, recordLimit = 10000000, conditions, conditionSign;
 
         if (args.name === null || args.name === "") {
@@ -337,20 +337,22 @@ INTERMediator_DBAdapter = {
             return;
         }
 
-        if (args['records'] == null) {
-            params = "access=select&name=" + encodeURIComponent(args['name']);
+        if (args.records === null) {
+            params = "access=select&name=" + encodeURIComponent(args.name);
         } else {
-            if (Number(args.records) === 0) {
-                params = "access=describe&name=" + encodeURIComponent(args['name']);
+            dbspec = INTERMediatorOnPage.getDBSpecification();
+            if (parseInt(args.records, 10) === 0 &&
+                dbspec["db-class"] !== null && dbspec["db-class"] === "FileMaker_FX") {
+                params = "access=describe&name=" + encodeURIComponent(args.name);
             } else {
-                params = "access=select&name=" + encodeURIComponent(args['name']);
+                params = "access=select&name=" + encodeURIComponent(args.name);
             }
-            if (args['uselimit'] === true
-                && Number(args.records) >= INTERMediator.pagedSize
-                && Number(INTERMediator.pagedSize) > 0) {
+            if (args.uselimit === true &&
+                parseInt(args.records, 10) >= INTERMediator.pagedSize &&
+                parseInt(INTERMediator.pagedSize, 10) > 0) {
                 recordLimit = INTERMediator.pagedSize;
             } else {
-                recordLimit = args['records'];
+                recordLimit = args.records;
             }
         }
 
@@ -368,15 +370,15 @@ INTERMediator_DBAdapter = {
             //noinspection JSDuplicatedDeclaration
             for (index in args['parentkeyvalue']) {
                 if (args['parentkeyvalue'].hasOwnProperty(index)) {
-                    params += "&foreign" + counter
-                    + "field=" + encodeURIComponent(index);
-                    params += "&foreign" + counter
-                    + "value=" + encodeURIComponent(args['parentkeyvalue'][index]);
+                    params += "&foreign" + counter +
+                        "field=" + encodeURIComponent(index);
+                    params += "&foreign" + counter +
+                        "value=" + encodeURIComponent(args['parentkeyvalue'][index]);
                     counter++;
                 }
             }
         }
-        if (args['useoffset'] && INTERMediator.startFrom != null) {
+        if (args.useoffset && INTERMediator.startFrom !== null) {
             params += "&start=" + encodeURIComponent(INTERMediator.startFrom);
         }
         extCount = 0;
@@ -504,15 +506,16 @@ INTERMediator_DBAdapter = {
             for (ix in result.dbresult) {
                 returnValue.count++;
             }
+            if (!(Number(args['records']) >= Number(INTERMediator.pagedSize) &&
+                Number(INTERMediator.pagedSize) > 0)) {
+                INTERMediator.pagedSize = Number(args['records']);
+            }
+            INTERMediator.pagedAllCount = Number(result.resultCount);
+            if (result.totalCount) {
+                INTERMediator.totalRecordCount = parseInt(result.totalCount, 10);
+            }
             if (( args['paging'] != null) && ( args['paging'] == true )) {
-                if (!(Number(args['records']) >= Number(INTERMediator.pagedSize)
-                    && Number(INTERMediator.pagedSize) > 0)) {
-                    INTERMediator.pagedSize = Number(args['records']);
-                }
-                INTERMediator.pagedAllCount = Number(result.resultCount);
-                if (result.totalCount) {
-                    INTERMediator.totalRecordCount = parseInt(result.totalCount, 10);
-                }
+                INTERMediator.pagination = true;
             }
         } catch (ex) {
             if (ex == "_im_requath_request_") {

--- a/DB_FileMaker_FX.php
+++ b/DB_FileMaker_FX.php
@@ -449,18 +449,17 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
         }
 
         $limitParam = 100000000;
-        if ($this->dbSettings->getRecordCount() > 0) {
-            $limitParam = $this->dbSettings->getRecordCount();
-        }
-        if (isset($context['records'])) {
-            $limitParam = $context['records'];
-        } elseif (isset($context['maxrecords'])) {
-            $limitParam = $context['maxrecords'];
-        }
-        if (isset($context['maxrecords'])
-            && intval($context['maxrecords']) >= $this->dbSettings->getRecordCount()
-            && $this->dbSettings->getRecordCount() > 0
-        ) {
+        if (isset($context['maxrecords'])) {
+            if (intval($context['maxrecords']) < $this->dbSettings->getRecordCount()) {
+                if (intval($context['maxrecords']) < intval($context['records'])) {
+                    $limitParam = intval($context['records']);
+                } else {
+                    $limitParam = intval($context['maxrecords']);
+                }
+            } else {
+                $limitParam = $this->dbSettings->getRecordCount();
+            }
+        } else if (isset($context['records'])) {
             $limitParam = $this->dbSettings->getRecordCount();
         }
         $this->setupFXforDB($this->dbSettings->getEntityForRetrieve(), $limitParam);

--- a/DB_FileMaker_FX.php
+++ b/DB_FileMaker_FX.php
@@ -460,7 +460,11 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                 $limitParam = $this->dbSettings->getRecordCount();
             }
         } else if (isset($context['records'])) {
-            $limitParam = $this->dbSettings->getRecordCount();
+            if (intval($context['records']) < $this->dbSettings->getRecordCount()) {
+                $limitParam = intval($context['records']);
+            } else {
+                $limitParam = $this->dbSettings->getRecordCount();
+            }
         }
         $this->setupFXforDB($this->dbSettings->getEntityForRetrieve(), $limitParam);
 

--- a/DB_PDO.php
+++ b/DB_PDO.php
@@ -24,6 +24,7 @@ class DB_PDO extends DB_AuthCommon implements DB_Access_Interface, DB_Interface_
      * @var int
      */
     private $mainTableCount = 0;
+    private $mainTableTotalCount = 0;
     /**
      * @var null
      */
@@ -598,6 +599,7 @@ class DB_PDO extends DB_AuthCommon implements DB_Access_Interface, DB_Interface_
     {
         $this->fieldInfo = null;
         $this->mainTableCount = 0;
+        $this->mainTableTotalCount = 0;
         $tableInfo = $this->dbSettings->getDataSourceTargetArray();
         $tableName = $this->dbSettings->getEntityForRetrieve();
         $signedUser = $this->authSupportUnifyUsernameAndEmail($this->dbSettings->getCurrentUser());
@@ -641,20 +643,29 @@ class DB_PDO extends DB_AuthCommon implements DB_Access_Interface, DB_Interface_
         }
         $this->mainTableCount = $result->fetchColumn(0);
 
+        // Count all records
+        $sql = "SELECT count(*) FROM {$viewOrTableName}";
+        $this->logger->setDebugMessage($sql);
+        $result = $this->link->query($sql);
+        if ($result === false) {
+            $this->errorMessageStore('Select:' . $sql);
+            return array();
+        }
+        $this->mainTableTotalCount = $result->fetchColumn(0);
+
         // Create SQL
         $limitParam = 100000000;
-        if ($this->dbSettings->getRecordCount() > 0) {
-            $limitParam = $this->dbSettings->getRecordCount();
-        }
-        if (isset($tableInfo['records'])) {
-            $limitParam = $tableInfo['records'];
-        } elseif (isset($tableInfo['maxrecords'])) {
-            $limitParam = $tableInfo['maxrecords'];
-        }
-        if (isset($tableInfo['maxrecords'])
-            && intval($tableInfo['maxrecords']) >= $this->dbSettings->getRecordCount()
-            && $this->dbSettings->getRecordCount() > 0
-        ) {
+        if (isset($tableInfo['maxrecords'])) {
+            if (intval($tableInfo['maxrecords']) < $this->dbSettings->getRecordCount()) {
+                if (intval($tableInfo['maxrecords']) < intval($tableInfo['records'])) {
+                    $limitParam = intval($tableInfo['records']);
+                } else {
+                    $limitParam = intval($tableInfo['maxrecords']);
+                }
+            } else {
+                $limitParam = $this->dbSettings->getRecordCount();
+            }
+        } else if (isset($tableInfo['records'])) {
             $limitParam = $this->dbSettings->getRecordCount();
         }
 
@@ -726,9 +737,18 @@ class DB_PDO extends DB_AuthCommon implements DB_Access_Interface, DB_Interface_
      * @param $dataSourceName
      * @return int
      */
-    function countQueryResult($dataSourceName)
+    public function countQueryResult($dataSourceName)
     {
         return $this->mainTableCount;
+    }
+
+    /**
+     * @param $dataSourceName
+     * @return int
+     */
+    public function getTotalCount($dataSourceName)
+    {
+        return $this->mainTableTotalCount;
     }
 
     /**

--- a/DB_PDO.php
+++ b/DB_PDO.php
@@ -666,7 +666,11 @@ class DB_PDO extends DB_AuthCommon implements DB_Access_Interface, DB_Interface_
                 $limitParam = $this->dbSettings->getRecordCount();
             }
         } else if (isset($tableInfo['records'])) {
-            $limitParam = $this->dbSettings->getRecordCount();
+            if (intval($tableInfo['records']) < $this->dbSettings->getRecordCount()) {
+                $limitParam = intval($tableInfo['records']);
+            } else {
+                $limitParam = $this->dbSettings->getRecordCount();
+            }
         }
 
         $skipParam = 0;

--- a/DB_Proxy.php
+++ b/DB_Proxy.php
@@ -774,6 +774,7 @@ class DB_Proxy extends DB_UseSharedObjects implements DB_Proxy_Interface
                 $result = $this->dbClass->getSchema($this->dbSettings->getTargetName());
                 $this->outputOfProcessing['dbresult'] = $result;
                 $this->outputOfProcessing['resultCount'] = 0;
+                $this->outputOfProcessing['totalCount'] = 0;
                 break;
             case 'select':
                 $result = $this->getFromDB($this->dbSettings->getTargetName());
@@ -789,10 +790,8 @@ class DB_Proxy extends DB_UseSharedObjects implements DB_Proxy_Interface
                 }
                 $this->outputOfProcessing['dbresult'] = $result;
                 $this->outputOfProcessing['resultCount'] = $this->countQueryResult($this->dbSettings->getTargetName());
-                if (get_class($this->dbClass) == 'DB_FileMaker_FX') {
-                    $this->outputOfProcessing['totalCount']
-                        = $this->dbClass->getTotalCount($this->dbSettings->getTargetName());
-                }
+                $this->outputOfProcessing['totalCount']
+                    = $this->dbClass->getTotalCount($this->dbSettings->getTargetName());
                 break;
             case 'update':
                 if (isset($tableInfo['protect-writing']) && is_array($tableInfo['protect-writing'])) {

--- a/INTER-Mediator-Context.js
+++ b/INTER-Mediator-Context.js
@@ -1085,6 +1085,7 @@ IMLibLocalContext = {
                             return function () {
                                 INTERMediator.startFrom = 0;
                                 IMLibUI.eventUpdateHandler(contextName);
+                                IMLibPageNavigation.navigationSetup();
                             };
                         })());
                         break;
@@ -1094,6 +1095,7 @@ IMLibLocalContext = {
                             return function () {
                                 INTERMediator.pagedSize = document.getElementById(idValue).value;
                                 IMLibUI.eventUpdateHandler(contextName);
+                                IMLibPageNavigation.navigationSetup();
                             };
                         })());
                         break;
@@ -1174,4 +1176,3 @@ IMLibLocalContext = {
         }
     }
 };
-

--- a/INTER-Mediator-DoOnStart.js
+++ b/INTER-Mediator-DoOnStart.js
@@ -16,6 +16,7 @@ INTERMediator.propertyIETridentSetup();
 if (INTERMediator.isIE && INTERMediator.ieVersion < 9) {
     INTERMediator.startFrom = 0;
     INTERMediator.pagedSize = 0;
+    INTERMediator.pagination = false;
     INTERMediator.additionalCondition = {};
     INTERMediator.additionalSortKey = {};
 } else {
@@ -33,6 +34,14 @@ if (INTERMediator.isIE && INTERMediator.ieVersion < 9) {
         },
         set: function (value) {
             INTERMediator.setLocalProperty("_im_pagedSize", value);
+        }
+    });
+    Object.defineProperty(INTERMediator, 'pagination', {
+        get: function () {
+            return INTERMediator.getLocalProperty("_im_pagination", 0);
+        },
+        set: function (value) {
+            INTERMediator.setLocalProperty("_im_pagination", value);
         }
     });
     Object.defineProperty(INTERMediator, 'additionalCondition', {
@@ -75,5 +84,3 @@ INTERMediatorLib.addEvent(window, "unload", function (e) {
 });
 
 // ****** This file should terminate on the new line. INTER-Mediator adds some codes before here. ****
-
-

--- a/INTER-Mediator-Navi.js
+++ b/INTER-Mediator-Navi.js
@@ -18,7 +18,7 @@ IMLibPageNavigation = {
             prevPageCount, nextPageCount, endPageCount, onNaviInsertFunction, onNaviDeleteFunction, onNaviCopyFunction;
 
         navigation = document.getElementById('IM_NAVIGATOR');
-        if (navigation != null) {
+        if (navigation !== null) {
             insideNav = navigation.childNodes;
             for (i = 0; i < insideNav.length; i++) {
                 navigation.removeChild(insideNav[i]);
@@ -49,21 +49,21 @@ IMLibPageNavigation = {
                 navigation.appendChild(node);
                 node.appendChild(document.createTextNode(
                     ((navLabel === null || navLabel[4] === null) ?
-                        INTERMediatorOnPage.getMessages()[1] : navLabel[4]) + (start + 1)
-                        + ((Math.min(start + pageSize, allCount) - start > 1) ?
-                        (((navLabel === null || navLabel[5] === null) ? "-" : navLabel[5])
-                            + Math.min(start + pageSize, allCount)) : '')
-                        + ((navLabel === null || navLabel[6] === null) ? " / " : navLabel[6]) + (allCount)
-                        + ((navLabel === null || navLabel[7] === null) ? "" : navLabel[7])));
-                node.setAttribute('class', 'IM_NAV_info');
+                        INTERMediatorOnPage.getMessages()[1] : navLabel[4]) + (start + 1) +
+                    ((Math.min(start + pageSize, allCount) - start > 1) ?
+                        (((navLabel === null || navLabel[5] === null) ? "-" : navLabel[5]) +
+                            Math.min(start + pageSize, allCount)) : "") +
+                    ((navLabel === null || navLabel[6] === null) ? " / " : navLabel[6]) + (allCount) +
+                    ((navLabel === null || navLabel[7] === null) ? "" : navLabel[7])));
+                node.setAttribute("class", "IM_NAV_info");
             }
 
-            if (navLabel === null || navLabel[0] !== false) {
+            if ((navLabel === null || navLabel[0] !== false) && INTERMediator.pagination === true) {
                 node = document.createElement('SPAN');
                 navigation.appendChild(node);
                 node.appendChild(document.createTextNode(
                     (navLabel === null || navLabel[0] === null) ? '<<' : navLabel[0]));
-                node.setAttribute('class', 'IM_NAV_button' + (start == 0 ? disableClass : ""));
+                node.setAttribute('class', 'IM_NAV_button' + (start === 0 ? disableClass : ""));
                 INTERMediatorLib.addEvent(node, 'click', function () {
                     INTERMediator_DBAdapter.unregister();
                     INTERMediator.startFrom = 0;
@@ -74,7 +74,7 @@ IMLibPageNavigation = {
                 navigation.appendChild(node);
                 node.appendChild(document.createTextNode(
                     (navLabel === null || navLabel[1] === null) ? '<' : navLabel[1]));
-                node.setAttribute('class', 'IM_NAV_button' + (start == 0 ? disableClass : ""));
+                node.setAttribute('class', 'IM_NAV_button' + (start === 0 ? disableClass : ""));
                 prevPageCount = (start - pageSize > 0) ? start - pageSize : 0;
                 INTERMediatorLib.addEvent(node, 'click', function () {
                     INTERMediator_DBAdapter.unregister();
@@ -87,8 +87,8 @@ IMLibPageNavigation = {
                 node.appendChild(document.createTextNode(
                     (navLabel === null || navLabel[2] === null) ? '>' : navLabel[2]));
                 node.setAttribute('class', 'IM_NAV_button' + (start + pageSize >= allCount ? disableClass : ""));
-                nextPageCount
-                    = (start + pageSize < allCount) ? start + pageSize : ((allCount - pageSize > 0) ? start : 0);
+                nextPageCount =
+                    (start + pageSize < allCount) ? start + pageSize : ((allCount - pageSize > 0) ? start : 0);
                 INTERMediatorLib.addEvent(node, 'click', function () {
                     INTERMediator_DBAdapter.unregister();
                     INTERMediator.startFrom = nextPageCount;
@@ -100,7 +100,7 @@ IMLibPageNavigation = {
                 node.appendChild(document.createTextNode(
                     (navLabel === null || navLabel[3] === null) ? '>>' : navLabel[3]));
                 node.setAttribute('class', 'IM_NAV_button' + (start + pageSize >= allCount ? disableClass : ""));
-                if (allCount % pageSize == 0) {
+                if (allCount % pageSize === 0) {
                     endPageCount = allCount - (allCount % pageSize) - pageSize;
                 } else {
                     endPageCount = allCount - (allCount % pageSize);
@@ -147,8 +147,8 @@ IMLibPageNavigation = {
                             navigation.appendChild(node);
                             node.appendChild(
                                 document.createTextNode(
-                                    INTERMediatorOnPage.getMessages()[3] + ': '
-                                        + IMLibPageNavigation.deleteInsertOnNavi[i]['name']));
+                                    INTERMediatorOnPage.getMessages()[3] + ': ' +
+                                        IMLibPageNavigation.deleteInsertOnNavi[i]['name']));
                             node.setAttribute('class', 'IM_NAV_button');
                             onNaviInsertFunction = function (a, b, c) {
                                 var contextName = a, keyValue = b, confirming = c;
@@ -170,8 +170,8 @@ IMLibPageNavigation = {
                             navigation.appendChild(node);
                             node.appendChild(
                                 document.createTextNode(
-                                    INTERMediatorOnPage.getMessages()[4] + ': '
-                                        + IMLibPageNavigation.deleteInsertOnNavi[i]['name']));
+                                    INTERMediatorOnPage.getMessages()[4] + ': ' +
+                                        IMLibPageNavigation.deleteInsertOnNavi[i]['name']));
                             node.setAttribute('class', 'IM_NAV_button');
                             onNaviDeleteFunction = function (a, b, c, d) {
                                 var contextName = a, keyName = b, keyValue = c, confirming = d;
@@ -193,8 +193,8 @@ IMLibPageNavigation = {
                             navigation.appendChild(node);
                             node.appendChild(
                                 document.createTextNode(
-                                    INTERMediatorOnPage.getMessages()[15] + ': '
-                                    + IMLibPageNavigation.deleteInsertOnNavi[i]['contextDef']['name']));
+                                    INTERMediatorOnPage.getMessages()[15] + ': ' +
+                                        IMLibPageNavigation.deleteInsertOnNavi[i]['contextDef']['name']));
                             node.setAttribute('class', 'IM_NAV_button');
                             onNaviCopyFunction = function (a, b) {
                                 var contextDef = a, record = b;
@@ -347,7 +347,7 @@ IMLibPageNavigation = {
         var newId;
 
         INTERMediatorOnPage.showProgress();
-        newId = IMLibUI.copyRecordImpl(contextDef, keyValue)
+        newId = IMLibUI.copyRecordImpl(contextDef, keyValue);
         if (newId > -1) {
             restore = INTERMediator.additionalCondition;
             INTERMediator.startFrom = 0;
@@ -403,8 +403,8 @@ IMLibPageNavigation = {
                         currentVal = INTERMediator_DBAdapter.db_query(checkQueryParameter);
                     } catch (ex) {
                         if (ex == "_im_requath_request_") {
-                            if (INTERMediatorOnPage.requireAuthentication
-                                && !INTERMediatorOnPage.isComplementAuthData()) {
+                            if (INTERMediatorOnPage.requireAuthentication &&
+                                !INTERMediatorOnPage.isComplementAuthData()) {
                                 INTERMediatorOnPage.clearCredentials();
                                 INTERMediatorOnPage.authenticating(
                                     function () {
@@ -418,8 +418,8 @@ IMLibPageNavigation = {
                         }
                     }
 
-                    if (currentVal.recordset == null
-                        || currentVal.recordset[0] === null) {
+                    if (currentVal.recordset === null ||
+                        currentVal.recordset[0] === null) {
                         alert(INTERMediatorLib.getInsertedString(
                             INTERMediatorOnPage.getMessages()[1003], [fieldArray.join(',')]));
                         return;
@@ -463,8 +463,8 @@ IMLibPageNavigation = {
 
                 } catch (ex) {
                     if (ex == "_im_requath_request_") {
-                        if (INTERMediatorOnPage.requireAuthentication
-                            && !INTERMediatorOnPage.isComplementAuthData()) {
+                        if (INTERMediatorOnPage.requireAuthentication &&
+                            !INTERMediatorOnPage.isComplementAuthData()) {
                             INTERMediatorOnPage.clearCredentials();
                             INTERMediatorOnPage.authenticating(
                                 function () {

--- a/INTER-Mediator.js
+++ b/INTER-Mediator.js
@@ -97,8 +97,8 @@ INTERMediator = {
         moreMessage = moreMessage === undefined ? "" : (" - " + moreMessage);
 
         if (INTERMediator.errorMessageByAlert) {
-            alert(INTERMediator.errorMessageOnAlert === null
-                ? (ex + moreMessage) : INTERMediator.errorMessageOnAlert);
+            alert(INTERMediator.errorMessageOnAlert === null ?
+                (ex + moreMessage) : INTERMediator.errorMessageOnAlert);
         }
 
         if ((typeof ex == 'string' || ex instanceof String)) {
@@ -125,8 +125,8 @@ INTERMediator = {
         if (INTERMediator.errorMessageByAlert) {
             INTERMediator.supressErrorMessageOnPage = true;
         }
-        if (!INTERMediator.supressErrorMessageOnPage
-            && INTERMediator.errorMessages.length > 0) {
+        if (!INTERMediator.supressErrorMessageOnPage &&
+            INTERMediator.errorMessages.length > 0) {
             debugNode = document.getElementById('_im_error_panel_4873643897897');
             if (debugNode === null) {
                 debugNode = document.createElement('div');
@@ -153,9 +153,9 @@ INTERMediator = {
                 debugNode.appendChild(document.createElement('hr'));
             }
         }
-        if (!INTERMediator.supressDebugMessageOnPage
-            && INTERMediator.debugMode
-            && INTERMediator.debugMessages.length > 0) {
+        if (!INTERMediator.supressDebugMessageOnPage &&
+            INTERMediator.debugMode &&
+            INTERMediator.debugMessages.length > 0) {
             debugNode = document.getElementById('_im_debug_panel_4873643897897');
             if (debugNode === null) {
                 debugNode = document.createElement('div');
@@ -453,8 +453,8 @@ INTERMediator = {
 
             // After work to set up popup menus.
             for (i = 0; i < postSetFields.length; i++) {
-                if (postSetFields[i]['value'] == ""
-                    && document.getElementById(postSetFields[i]['id']).tagName == "SELECT") {
+                if (postSetFields[i]['value'] === "" &&
+                    document.getElementById(postSetFields[i]['id']).tagName == "SELECT") {
                     // for compatibility with Firefox when the value of select tag is empty.
                     emptyElement = document.createElement('option');
                     emptyElement.setAttribute("value", "");
@@ -508,8 +508,8 @@ INTERMediator = {
                     if (INTERMediatorLib.isEnclosure(node, false)) { // Linked element and an enclosure
                         className = INTERMediatorLib.getClassAttributeFromNode(node);
                         attr = node.getAttribute("data-im-control");
-                        if ((className && className.match(/_im_post/))
-                            || (attr && attr == "post")) {
+                        if ((className && className.match(/_im_post/)) ||
+                            (attr && attr == "post")) {
                             setupPostOnlyEnclosure(node);
                         } else {
                             if (INTERMediator.isIE) {
@@ -644,7 +644,7 @@ INTERMediator = {
                     newNode = node.appendChild(repeatersOriginal[i]);
 
                     // for compatibility with Firefox
-                    if (repeatersOriginal[i].getAttribute("selected") != null) {
+                    if (repeatersOriginal[i].getAttribute("selected") !== null) {
                         selectedNode = newNode;
                     }
                     if (selectedNode !== undefined) {
@@ -679,7 +679,7 @@ INTERMediator = {
                         contextObj.setOriginal(repeatersOriginal);
                         if (relationDef) {
                             for (index in relationDef) {
-                                if (relationDef[index]["portal"] == true) {
+                                if (relationDef[index]["portal"] === true) {
                                     currentContextDef["portal"] = true;
                                 }
                                 joinField = relationDef[index]['join-field'];
@@ -687,8 +687,8 @@ INTERMediator = {
                                 for (fieldName in parentObjectInfo) {
                                     if (fieldName == relationDef[index]['join-field']) {
                                         contextObj.addDependingObject(parentObjectInfo[fieldName]);
-                                        contextObj.dependingParentObjectInfo
-                                            = JSON.parse(JSON.stringify(parentObjectInfo));
+                                        contextObj.dependingParentObjectInfo =
+                                            JSON.parse(JSON.stringify(parentObjectInfo));
                                     }
                                 }
                             }
@@ -741,7 +741,7 @@ INTERMediator = {
             targetRecordset = targetRecords.recordset;
             targetTotalCount = targetRecords.totalCount;
 
-            if (targetRecords.count == 0) {
+            if (targetRecords.count === 0) {
                 for (i = 0; i < repeatersOriginal.length; i++) {
                     newNode = repeatersOriginal[i].cloneNode(true);
                     nodeClass = INTERMediatorLib.getClassAttributeFromNode(newNode);
@@ -769,7 +769,7 @@ INTERMediator = {
                     }
 
                     dbspec = INTERMediatorOnPage.getDBSpecification();
-                    if (dbspec["db-class"] != null && dbspec["db-class"] == "FileMaker_FX") {
+                    if (dbspec["db-class"] !== null && dbspec["db-class"] == "FileMaker_FX") {
                         keyField = currentContextDef["key"] ? currentContextDef["key"] : "-recid";
                     } else {
                         keyField = currentContextDef["key"] ? currentContextDef["key"] : "id";
@@ -777,8 +777,8 @@ INTERMediator = {
 
                     if (currentContextDef["relation"]) {
                         for (i = 0; i < Object.keys(currentContextDef["relation"]).length; i++) {
-                            if (currentContextDef["relation"][i]["portal"]
-                                && Number(currentContextDef["relation"][i]["portal"]) === 1) {
+                            if (currentContextDef["relation"][i]["portal"] &&
+                                Number(currentContextDef["relation"][i]["portal"]) === 1) {
                                 usePortal = true;
                             }
                         }
@@ -828,8 +828,8 @@ INTERMediator = {
                     }
                 }
 
-                if (currentContextDef['portal'] != true
-                    || (currentContextDef['portal'] == true && targetTotalCount > 0)) {
+                if (currentContextDef['portal'] !== true ||
+                    (currentContextDef['portal'] === true && targetTotalCount > 0)) {
                     nameTable = {};
                     for (k = 0; k < currentLinkedNodes.length; k++) {
                         try {
@@ -864,7 +864,7 @@ INTERMediator = {
                             for (j = 0; j < linkInfoArray.length; j++) {
                                 nInfo = INTERMediatorLib.getNodeInfoArray(linkInfoArray[j]);
                                 curVal = targetRecordset[ix][nInfo['field']];
-                                if (!INTERMediator.isDBDataPreferable || curVal != null) {
+                                if (!INTERMediator.isDBDataPreferable || curVal !== null) {
                                     IMLibCalc.updateCalculationInfo(
                                         contextObj, keyingValue, currentContextDef, nodeId, nInfo, targetRecordset[ix]);
                                 }
@@ -895,9 +895,9 @@ INTERMediator = {
                                 }
                             }
 
-                            if (isContext
-                                && !isInsidePostOnly
-                                && (nodeTag == 'INPUT' || nodeTag == 'SELECT' || nodeTag == 'TEXTAREA')) {
+                            if (isContext &&
+                                !isInsidePostOnly &&
+                                (nodeTag == 'INPUT' || nodeTag == 'SELECT' || nodeTag == 'TEXTAREA')) {
                                 //IMLibChangeEventDispatch.setExecute(nodeId, IMLibUI.valueChange);
                                 var changeFunction = function (a) {
                                     var id = a;
@@ -934,7 +934,7 @@ INTERMediator = {
                     }
                 }
 
-                if (usePortal == true) {
+                if (usePortal === true) {
                     keyField = "-recid";
                     foreignField = currentContextDef['name'] + "::-recid";
                     foreignValue = targetRecordset[ix][foreignField];
@@ -952,13 +952,13 @@ INTERMediator = {
                 setupCopyButton(encNodeTag, repNodeTag, repeatersOneRec[repeatersOneRec.length - 1],
                     currentContextDef, targetRecordset[ix]);
 
-                if (currentContextDef['portal'] != true
-                    || (currentContextDef['portal'] == true && targetTotalCount > 0)) {
+                if (currentContextDef['portal'] !== true ||
+                    (currentContextDef['portal'] === true && targetTotalCount > 0)) {
                     newlyAddedNodes = [];
                     insertNode = null;
                     if (!contextObj.sequencing) {
                         indexContext = contextObj.checkOrder(targetRecordset[ix]);
-                        insertNode = contextObj.getRepeaterEndNode(indexContext + 1)
+                        insertNode = contextObj.getRepeaterEndNode(indexContext + 1);
                     }
                     for (i = 0; i < repeatersOneRec.length; i++) {
                         newNode = repeatersOneRec[i];
@@ -991,11 +991,11 @@ INTERMediator = {
             var ix, keyField, targetRecords, counter, oneRecord, isMatch, index, fieldName, condition,
                 recordNumber, useLimit, optionalCondition = [], pagingValue, recordsValue, i, recordset = [];
 
-            if (currentContextDef['cache'] == true) {
+            if (currentContextDef['cache'] === true) {
                 try {
                     if (!INTERMediatorOnPage.dbCache[currentContextDef['name']]) {
-                        INTERMediatorOnPage.dbCache[currentContextDef['name']]
-                            = INTERMediator_DBAdapter.db_query({
+                        INTERMediatorOnPage.dbCache[currentContextDef['name']] =
+                            INTERMediator_DBAdapter.db_query({
                             name: currentContextDef['name'],
                             records: null,
                             paging: null,
@@ -1056,12 +1056,34 @@ INTERMediator = {
                     if (currentContextDef["records"] && currentContextDef["paging"]) {
                         useLimit = true;
                     }
-                    if (currentContextDef['maxrecords'] && useLimit && Number(INTERMediator.pagedSize) > 0
-                        && Number(currentContextDef['maxrecords']) >= Number(INTERMediator.pagedSize)) {
-                        recordNumber = Number(INTERMediator.pagedSize);
+
+                    if (currentContextDef.maxrecords) {
+                        if (parseInt(INTERMediator.pagedSize, 10) === 0) {
+                            if (currentContextDef.records) {
+                                recordNumber = parseInt(currentContextDef.records, 10);
+                            } else {
+                                recordNumber = parseInt(currentContextDef.maxrecords, 10);
+                            }
+                        } else {
+                            if (parseInt(currentContextDef.maxrecords, 10) < parseInt(INTERMediator.pagedSize, 10)) {
+                                if (parseInt(currentContextDef.maxrecords, 10) < parseInt(currentContextDef.records, 10)) {
+                                    recordNumber = parseInt(currentContextDef.records, 10);
+                                } else {
+                                    recordNumber = parseInt(currentContextDef.maxrecords, 10);
+                                }
+                            } else {
+                                recordNumber = parseInt(INTERMediator.pagedSize, 10);
+                            }
+                        }
                     } else {
-                        recordNumber = Number(currentContextDef['records']);
+                        if (parseInt(INTERMediator.pagedSize, 10) === 0 ||
+                            (parseInt(currentContextDef.records, 10) < parseInt(INTERMediator.pagedSize, 10))) {
+                            recordNumber = parseInt(currentContextDef.records, 10);
+                        } else {
+                            recordNumber = parseInt(INTERMediator.pagedSize, 10);
+                        }
                     }
+                    INTERMediator.setLocalProperty("_im_pagedSize", recordNumber);
 
                     targetRecords = {};
                     if (currentContextDef["portal"] === true) {

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -75,7 +75,7 @@ Ver.5.2 (in development)
   the page file includes "?media=". The affected version is 5.1 only.
 - [BUG FIX] Fix loading English MessageStrings class when the value of Accept-Language request header 
   includes 'ja'.
-- [BUG FIX] Fix the behavior of 'maxrecords' key for pagination.
+- [BUG FIX] Fix the behavior of 'maxrecords' key for pagination (Thanks to Kazuaki Osawa).
 
 Ver.5.1 (May 22, 2015)
 - Support uploading a file to FileMaker's container field when using FileMaker Server 13 or later.

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -33,6 +33,13 @@ Ver.5.2 (in development)
       $prohibitIgnoreCondition = true;
       $httpAccounts = array('user'=>'testtest');
       $httpRedirectURL = "http://10.0.1.226/im/Sample_products/products_MySQL.html";
+- Now setting the 'records' key manually in the definition file to a value bigger than maxrecords
+  will actually bring maxrecords to the same value, no need to repeat yourself.
+- Update the navigation bar automaticallay after updating the value of _@condition:... and
+  _@limitnumber:contextname.
+- Hide buttons and the input area for pagination on the navigation bar when the 'paging' key
+  is not set.
+- Add getTotalCount() to DB_PDO class to get the total number of records in the main table.
 - Add circle.yml to test with CircleCI.
 - Update TestDB.fmp12 and TestDB.fp7 to add the last updated date on "person_layout" layout.
 - Update sample_schema_mysql.txt, TestDB.fmp12, TestDB_clone.fmp12 and TestDB.fp7 to add
@@ -68,6 +75,7 @@ Ver.5.2 (in development)
   the page file includes "?media=". The affected version is 5.1 only.
 - [BUG FIX] Fix loading English MessageStrings class when the value of Accept-Language request header 
   includes 'ja'.
+- [BUG FIX] Fix the behavior of 'maxrecords' key for pagination.
 
 Ver.5.1 (May 22, 2015)
 - Support uploading a file to FileMaker's container field when using FileMaker Server 13 or later.


### PR DESCRIPTION
Fixed the behavior of 'maxrecords' key for pagination and modify the following items for pagination.

- Now setting the 'records' key manually in the definition file to a value bigger than maxrecords will actually bring maxrecords to the same value, no need to repeat yourself.
- Update the navigation bar automaticallay after updating the value of _@condition:... and _@limitnumber:contextname.
- Hide buttons and the input area for pagination on the navigation bar when the 'paging' key is not set.
- Add getTotalCount() to DB_PDO class to get the total number of records in the main table.