### PR TITLE
Fix handling INTERMediator.pagedSize (version 5.2-dev)

### DIFF
--- a/Adapter_DBServer.js
+++ b/Adapter_DBServer.js
@@ -506,10 +506,6 @@ INTERMediator_DBAdapter = {
             for (ix in result.dbresult) {
                 returnValue.count++;
             }
-            if (!(Number(args.records) >= Number(INTERMediator.pagedSize) &&
-                Number(INTERMediator.pagedSize) > 0)) {
-                INTERMediator.pagedSize = parseInt(args.records, 10);
-            }
             if (INTERMediator.pagedAllCount === 0 && INTERMediator.pagedAllCount < result.resultCount) {
                 INTERMediator.pagedAllCount = parseInt(result.resultCount, 10);
                 if (result.totalCount) {
@@ -518,6 +514,10 @@ INTERMediator_DBAdapter = {
             }
             if ((args.paging !== null) && (Boolean(args.paging) === true)) {
                 INTERMediator.pagination = true;
+                if (!(Number(args.records) >= Number(INTERMediator.pagedSize) &&
+                    Number(INTERMediator.pagedSize) > 0)) {
+                    INTERMediator.pagedSize = parseInt(args.records, 10);
+                }
             }
         } catch (ex) {
             if (ex == "_im_requath_request_") {


### PR DESCRIPTION
Fixed handling INTERMediator.pagedSize after updating a record and using pagination function (The affected version is 5.2-dev only).