### PR TITLE
Prevent move_uploaded_file() NULL byte injection in file name for PHP 5.2.x and PHP 5.3.x

### DIFF
--- a/FileUploader.php
+++ b/FileUploader.php
@@ -123,7 +123,7 @@ class FileUploader
                 $filePath = $tmpDir . DIRECTORY_SEPARATOR . $fileName;
             }
         }
-        $result = move_uploaded_file($fileInfo['tmp_name'], $filePath);
+        $result = move_uploaded_file($util->removeNull($fileInfo['tmp_name']), $filePath);
         if (!$result) {
             if (isset($_POST["_im_redirect"])) {
                 header("Location: {$_POST["_im_redirect"]}");

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -58,6 +58,9 @@ Ver.5.2 (in development)
 - Add .codeclimate.yml.
 - Some terms of "new", "load", "edit" replaced to CRUD words "create", "read", "update".
   But all original terms are still available.
+- [SECURITY FIX] Update FileUploader.php to prevent move_uploaded_file() NULL byte injection in
+  file name (CVE-2015-2348) for PHP 5.2.x and PHP 5.3.x (CVE-2015-2348 was fixed in PHP 5.4.39,
+  PHP 5.5.23 and PHP 5.6.7).
 - [BUG FIX] The definition file editor supports the 'soft-delete' key, and also the field which
   can't contain ether boolean or string value appropriately.
 - [BUG FIX] The definition file editor supports the 'pusher-app_id', 'pusher-key' and


### PR DESCRIPTION
Updated FileUploader.php to prevent move_uploaded_file() NULL byte injection in file name (CVE-2015-2348) for PHP 5.2.x and PHP 5.3.x (CVE-2015-2348 was fixed in PHP 5.4.39, PHP 5.5.23 and PHP 5.6.7).