### PR TITLE
Fix detecting the Post Only Mode

### DIFF
--- a/INTER-Mediator-Lib.js
+++ b/INTER-Mediator-Lib.js
@@ -321,8 +321,8 @@ var INTERMediatorLib = {
             if ((enclosureTag === 'DIV' || enclosureTag === 'SPAN' )) {
                 enclosureClass = INTERMediatorLib.getClassAttributeFromNode(enclosure);
                 enclosureDataAttr = enclosure.getAttribute("data-im-control");
-                if ((enclosureClass && enclosureClass.indexOf('_im_enclosure') >= 0) ||
-                    (enclosureDataAttr && enclosureDataAttr == "enclosure")) {
+                if ((enclosureClass && enclosureClass.indexOf(INTERMediatorLib.rollingEnclosureClassName) >= 0) ||
+                    (enclosureDataAttr && enclosureDataAttr.indexOf("enclosure") >= 0)) {
                     repeaterClass = INTERMediatorLib.getClassAttributeFromNode(repeater);
                     repeaterDataAttr = repeater.getAttribute("data-im-control");
                     if ((repeaterTag === 'DIV' || repeaterTag === 'SPAN') &&

--- a/INTER-Mediator.js
+++ b/INTER-Mediator.js
@@ -510,7 +510,7 @@ INTERMediator = {
                         className = INTERMediatorLib.getClassAttributeFromNode(node);
                         attr = node.getAttribute("data-im-control");
                         if ((className && className.match(/_im_post/)) ||
-                            (attr && attr == "post")) {
+                            (attr && attr.indexOf("post") >= 0)) {
                             setupPostOnlyEnclosure(node);
                         } else {
                             if (INTERMediator.isIE) {

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -28,6 +28,8 @@ Ver.5.3 (in development)
 - [BUG FIX] Fix detection of params.php file.
 - [BUG FIX] Fix loading DB_TextFile class. The affected version is 5.2 only.
 - [BUG FIX] Modify INTERMediator.totalRecordCount after IMLibPageNavigation.deleteRecordFromNavi method.
+- [BUG FIX] Fix detecting the Post Only Mode when the value of the enclosure's data-im-control element
+  is "enclosure post".
 
 Ver.5.2 (August 24, 2015)
 - Record Copying is supported for single record, and also with associated records for PDO.

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"version":"5.3-dev","releasedate":"2015-09-17"}
+{"version":"5.3-dev","releasedate":"2015-09-19"}


### PR DESCRIPTION
Fixed detecting the Post Only Mode when the value of the enclosure's data-im-control element is "enclosure post".