### PR TITLE
Avoid outputting messages in an error log file if there is no portal objects on the layout

### DIFF
--- a/DB_FileMaker_FX.php
+++ b/DB_FileMaker_FX.php
@@ -797,7 +797,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                             if (isset($relatedset['record'])) {
                                 foreach ($relatedset['record'] as $relatedrecord) {
                                     $relatedArray = array('-recid' => $record['@attributes']['record-id']);
-                                    if (isset($relatedset['@attributes'])) {
+                                    if (isset($relatedset['@attributes']) && isset($relatedrecord['@attributes'])) {
                                         $relatedArray += array(
                                             $relatedset['@attributes']['table'] . '::-recid'
                                             => $relatedrecord['@attributes']['record-id']

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -53,6 +53,8 @@ Ver.5.3 (in development)
   FileMaker Server 12 or later if using FileMaker Server.
 - The second parameter of the doAfterCreateToDB method is passed all fields of the newly created record.
   Previously it was just a key field value of new record.
+- Avoid outputting messages in an error log file if there is no portal objects on the layout when using 
+  FileMaker Server.
 - [BUG FIX] Fix detection of params.php file.
 - [BUG FIX] Fix loading DB_TextFile class. The affected version is 5.2 only.
 - [BUG FIX] Modify INTERMediator.totalRecordCount after IMLibPageNavigation.deleteRecordFromNavi method.

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"version":"5.3-dev","releasedate":"2015-11-03"}
+{"version":"5.3-dev","releasedate":"2015-11-14"}


### PR DESCRIPTION
Related commit: f6eaba22e0d7a47e2e10840e54b8b85fb897c701