### PR TITLE
Update FileUploader.php to prevent the HTTP header injection in header() of PHP 5.2/5.3

### DIFF
--- a/FileUploader.php
+++ b/FileUploader.php
@@ -54,7 +54,6 @@ class FileUploader
                 $dbProxyInstance->exportOutputDataAsJSON();
                 return;
             }
-            error_log($url);
         }
         
         if (!isset($options['media-root-dir']) && $useContainer === FALSE) {

--- a/INTER-Mediator-UnitTest/FileUploader_Test.php
+++ b/INTER-Mediator-UnitTest/FileUploader_Test.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * FileUploader_Test file
+ */
+require_once(dirname(__FILE__) . '/../FileUploader.php');
+
+class FileUploader_Test extends PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->uploader = new FileUploader();
+    }
+    
+    public function test_getRedirectUrl()
+    {
+        if (((float)phpversion()) >= 5.3) {
+            $this->reflectionMethod = new ReflectionMethod('FileUploader', 'getRedirectUrl');
+            $this->reflectionMethod->setAccessible(true);
+            
+            $expected = 'https://inter-mediator.com/';
+            $result = $this->reflectionMethod->invokeArgs($this->uploader, array('https://inter-mediator.com/'));
+            $this->assertEquals($expected, $result);
+
+            $result = $this->reflectionMethod->invokeArgs($this->uploader, array('https://inter-mediator.com/%0a'));
+            $this->assertNull($result);
+
+            $result = $this->reflectionMethod->invokeArgs($this->uploader, array('https://inter-mediator.com/%0d'));
+            $this->assertNull($result);
+
+            $result = $this->reflectionMethod->invokeArgs($this->uploader, array('https://inter-mediator.com/%0A'));
+            $this->assertNull($result);
+            
+            $result = $this->reflectionMethod->invokeArgs($this->uploader, array('https://inter-mediator.com/%0D'));
+            $this->assertNull($result);
+
+            $result = $this->reflectionMethod->invokeArgs($this->uploader, array('https://inter-mediator.com/%0d%0a%20'));
+            $this->assertNull($result);
+        }
+    }
+
+}

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -50,12 +50,12 @@ Ver.5.3 (in development)
 - Add .gitlab-ci.yml for GitLab CI.
 - Update buster.js and package.json for unit testing.
 - Avoid outputting an error message in an error log file in case of an invalid request.
-- [INFO] FileMaker Server 11 has been deprecated. In the near future, INTER-Mediator will require
-  FileMaker Server 12 or later if using FileMaker Server.
 - The second parameter of the doAfterCreateToDB method is passed all fields of the newly created record.
   Previously it was just a key field value of new record.
 - Avoid outputting messages in an error log file if there is no portal objects on the layout when using 
   FileMaker Server.
+- [INFO] FileMaker Server 11 has been deprecated. In the near future, INTER-Mediator will require
+  FileMaker Server 12 or later if using FileMaker Server.
 - [SECURITY FIX] Update FileUploader.php to prevent the HTTP header injection in PHP's header() for 
   Internet Explorer and PHP 5.2.x/PHP 5.3.x (Fixed in PHP 5.4.38, PHP 5.5.22 and PHP 5.6.6).
 - [BUG FIX] Fix detection of params.php file.

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -56,6 +56,8 @@ Ver.5.3 (in development)
   Previously it was just a key field value of new record.
 - Avoid outputting messages in an error log file if there is no portal objects on the layout when using 
   FileMaker Server.
+- [SECURITY FIX] Update FileUploader.php to prevent the HTTP header injection in PHP's header() for 
+  Internet Explorer and PHP 5.2.x/PHP 5.3.x (Fixed in PHP 5.4.38, PHP 5.5.22 and PHP 5.6.6).
 - [BUG FIX] Fix detection of params.php file.
 - [BUG FIX] Fix loading DB_TextFile class. The affected version is 5.2 only.
 - [BUG FIX] Modify INTERMediator.totalRecordCount after IMLibPageNavigation.deleteRecordFromNavi method.

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"version":"5.3-dev","releasedate":"2015-12-23"}
+{"version":"5.3-dev","releasedate":"2015-12-26"}


### PR DESCRIPTION
Added FileUploader_Test.php and fixed for Internet Explorer and PHP 5.2.x/PHP 5.3.x.

Related URL:
http://blog.tokumaru.org/2015/12/phphttp.html