### PR TITLE
Fix setup delete/copy buttons

### DIFF
--- a/INTER-Mediator.js
+++ b/INTER-Mediator.js
@@ -1529,15 +1529,19 @@ INTERMediator = {
                     'todo': copyJSFunction(currentContext, currentRecord[currentContextDef['key']])
                 });
                 switch (encNodeTag) {
-                    case 'TBODY':
-                        tdNodes = repeaters[repeaters.length - 1].getElementsByTagName('TD');
+                    case "TBODY":
+                        tdNodes = repeaters[repeaters.length - 1].getElementsByTagName("TD");
                         tdNode = tdNodes[tdNodes.length - 1];
                         tdNode.appendChild(buttonNode);
                         break;
-                    case 'SELECT':
+                    case "SELECT":
                         break;
                     default:
-                        repeaters.push(buttonNode);
+                        if (repeaters[0] && repeaters[0].childNodes) {
+                            repeaters[repeaters.length - 1].appendChild(buttonNode);
+                        } else {
+                            repeaters.push(buttonNode);
+                        }
                         break;
                 }
             }
@@ -1593,16 +1597,20 @@ INTERMediator = {
                         currentContextDef['repeat-control'].match(/confirm-delete/i))
                 });
                 switch (encNodeTag) {
-                    case 'TBODY':
-                        tdNodes = repeaters[repeaters.length - 1].getElementsByTagName('TD');
+                    case "TBODY":
+                        tdNodes = repeaters[repeaters.length - 1].getElementsByTagName("TD");
                         tdNode = tdNodes[tdNodes.length - 1];
                         tdNode.appendChild(buttonNode);
                         break;
-                    case 'SELECT':
+                    case "SELECT":
                         // OPTION tag can't contain any other tags.
                         break;
                     default:
-                        repeaters.push(buttonNode);
+                        if (repeaters[0] && repeaters[0].childNodes) {
+                            repeaters[repeaters.length - 1].appendChild(buttonNode);
+                        } else {
+                            repeaters.push(buttonNode);
+                        }
                         break;
                 }
             } else {

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"version":"5.3-RC2","releasedate":"2016-02-11"}
+{"version":"5.3-RC2","releasedate":"2016-02-13"}


### PR DESCRIPTION
The node of the generated Delete or Copy button isn't in the repeater node in 5.3-RC1 in the following case. The pull request reverts to normal (version 5.2).

[HTML]
```
<div class="_im_enclosure">
  <div class="_im_repeater" data-im="asset@name"></div>
</div>
```

[Result1 / 5.3-dev 2016-02-06 (or this pull request)]
```
<div class="_im_enclosure">
  <div class="_im_repeater" data-im="asset@name">AssetName1<button id="IM_Button_1" class="IM_Button_Delete">削除</button></div>
  <div class="_im_repeater" data-im="asset@name">AssetName2<button id="IM_Button_2" class="IM_Button_Delete">削除</button></div>
</div>
```

[Result2 / 5.3-RC1 2016-02-09]
```
<div class="_im_enclosure">
  <div class="_im_repeater" data-im="asset@name">AssetName</div>
  <button id="IM_Button_1" class="IM_Button_Delete">削除</button>
  <div class="_im_repeater" data-im="asset@name">AssetName2</div>
  <button id="IM_Button_1" class="IM_Button_Delete">削除</button>
</div>
```