### PR TITLE
Reduce error messages when the mbstring extension is disabled

### DIFF
--- a/Adapter_DBServer.js
+++ b/Adapter_DBServer.js
@@ -164,10 +164,11 @@ INTERMediator_DBAdapter = {
                 }
             }
         } catch (e) {
-            INTERMediator.setErrorMessage(e,
-                INTERMediatorLib.getInsertedString(
-                    INTERMediatorOnPage.getMessages()[errorMessageNumber], [e, myRequest.responseText]));
-
+            if (INTERMediatorOnPage.getIMRootPath() !== "[ERROR]") {
+                INTERMediator.setErrorMessage(e,
+                    INTERMediatorLib.getInsertedString(
+                        INTERMediatorOnPage.getMessages()[errorMessageNumber], [e, myRequest.responseText]));
+            }
         }
         if (accessURL.indexOf("access=changepassword&newpass=") === 0) {
             return changePasswordResult;

--- a/GenerateJSCode.php
+++ b/GenerateJSCode.php
@@ -159,6 +159,8 @@ class GenerateJSCode
             $pathToIMRootDir = mb_ereg_replace(
                 mb_ereg_replace("\\x5c", "/", "^{$documentRootPrefix}" . filter_var($_SERVER['DOCUMENT_ROOT'])),
                 "", mb_ereg_replace("\\x5c", "/", dirname(__FILE__)));
+        } else {
+            $pathToIMRootDir = '[ERROR]';
         }
 
         $this->generateAssignJS(

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -32,6 +32,7 @@ Ver.5.4 (in development)
 - The IMLibUI.valueChange method is locked with the id attribute value to prevent the error when multiple
   updating processes run simultaneously.
 - Supporting jQuery File Upload. Check the file Samples/Sample_website/fileupload_jQuery_MySQL.html.
+- Reduce error messages when the mbstring extension is disabled.
 - [BUG FIX] Fix the issue of MediaAccess class and the file upload component when using the Native
   Authentication for mobile devices. The affected version is 5.3 only.
 - [BUG FIX] INTERMediatorOnPage.defaultBackgroundImage affects as expected.

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"version":"5.4-dev","releasedate":"2016-06-05"}
+{"version":"5.4-dev","releasedate":"2016-06-10"}


### PR DESCRIPTION
For FileMaker Server users using Windows Server.