### PR TITLE
Fix DB_FileMaker_FX class not to throw an exception when failed to convert a value using DataConverter classes

### DIFF
--- a/DB_FileMaker_FX.php
+++ b/DB_FileMaker_FX.php
@@ -787,13 +787,12 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
                         $fieldName = $field['@attributes']['name'];
                         $fieldValue = '';
                         if (isset($field['data']) && !is_null($field['data'])) {
-                            $fieldValue = $this->formatter->formatterFromDB(
-                                "{$tableName}{$this->dbSettings->getSeparator()}{$fieldName}", $field['data']);
-//                            if ($dataSourceName != $tableName && $fieldValue == $field['data']) {
-//                                // for the compatiblity of ver.4.5 or preivious (DB_FileMaker_FX class only)
-//                                $fieldValue = $this->formatter->formatterFromDB(
-//                                    "{$tableName}{$this->dbSettings->getSeparator()}{$fieldName}", $field['data']);
-//                            }
+                            try {
+                                $fieldValue = $this->formatter->formatterFromDB(
+                                    "{$tableName}{$this->dbSettings->getSeparator()}{$fieldName}", $field['data']);
+                            } catch (Exception $e) {
+                                $fieldValue = $field['data'];
+                            }
                             if ($fieldName == $keyField && $keyField != $this->getDefaultKey()) {
                                 $this->queriedPrimaryKeys[] = $field['data'];
                             }

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -51,6 +51,8 @@ Ver.5.4 (in development)
 - [BUG FIX] Enrolment methods had a bug in case of FileMaker Server with issuedhash for SQLite.
 - [BUG FIX] When the text field bond to local context didn't update calculated property.
 - [BUG FIX] Authentication prevented in case of just specify on the second parameter of IM_Entry.
+- [BUG FIX] Fix DB_FileMaker_FX class not to throw an exception when failed to convert a value 
+  using DataConverter classes.
 
 Ver.5.3 (February 21, 2016)
 - Support OAuth2 with OAuthAuth.php class and the sample redirected page is OAuthCatcher.php


### PR DESCRIPTION
Example)
- Using FMDateTime converter.
- Field type is 'Time', but a value of the field is '2016/06/22'.