### PR TITLE
Fix adding a portal record when using portal access mode for FileMaker Server

### DIFF
--- a/INTER-Mediator-UI.js
+++ b/INTER-Mediator-UI.js
@@ -590,16 +590,21 @@ var IMLibUI = {
                 relatedRecordSet.push({field: targetPortalField + '.0', value: targetPortalValue});
             }
 
-            INTERMediator_DBAdapter.db_update({
-                name: currentObj.parentContext.contextName,
-                conditions: [{
-                    field: currentContext['key'] ? currentContext['key'] : '-recid',
-                    operator: '=',
-                    value: foreignValues.id
-                }],
-                dataset: relatedRecordSet
-            });
-            INTERMediator.constructMain();
+            if (currentContext.relation && currentContext.relation[0] &&
+                currentContext.relation[0]['join-field']) {
+                INTERMediator_DBAdapter.db_update({
+                    name: currentObj.parentContext.contextName,
+                    conditions: [{
+                        field: currentContext.relation[0]['join-field'],
+                        operator: '=',
+                        value: foreignValues.id
+                    }],
+                    dataset: relatedRecordSet
+                });
+                INTERMediator.constructMain();
+            } else {
+                INTERMediator.setErrorMessage('Insert Error (Portal Access Mode)', 'EXCEPTION-4');
+            }
         } else {
             INTERMediator_DBAdapter.db_createRecord_async(
                 {name: targetName, dataset: recordSet},

--- a/INTER-Mediator.js
+++ b/INTER-Mediator.js
@@ -734,7 +734,8 @@ var INTERMediator = {
                         return elm;
                     });
                     contextObj.setRelationWithParent(currentRecord, parentObjectInfo, currentContextObj);
-                    if (Boolean(currentContextDef.portal) === true) {
+                    if (currentContextDef.relation && currentContextDef.relation[0] &&
+                        Boolean(currentContextDef.relation[0].portal) === true) {
                         currentContextDef['currentrecord'] = currentRecord;
                         keyValue = currentRecord['-recid'];
                     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"version":"5.4-RC2","releasedate":"2016-07-30"}
+{"version":"5.4-RC2","releasedate":"2016-08-01"}


### PR DESCRIPTION
Fix adding a portal record when the value of primary key and internal record id is different.