### PR TITLE
Fix focusing to the other field with Chrome and Safari in some cases (after changing the id of the element manually in version 5.4-dev)

### DIFF
--- a/INTER-Mediator-Element.js
+++ b/INTER-Mediator-Element.js
@@ -192,7 +192,7 @@ var IMLibElement = {
             var idValue = element.id;
             var elementCapt = element;
             INTERMediatorLib.addEvent(element, 'blur', function (event) {
-                if (!IMLibUI.valueChange(idValue, true)) {
+                if (!IMLibUI.valueChange(idValue, true) && this.id === idValue) {
                     elementCapt.focus();
                 }
             });

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"version":"5.4-RC3","releasedate":"2016-08-17"}
+{"version":"5.4-RC3","releasedate":"2016-08-18"}


### PR DESCRIPTION
Related commit is 638a788721a64a9ef85685ab5e45b64553baa439.