### PR TITLE
Avoid outputting a warning in an error log file in case of using PHP 5.6

### DIFF
--- a/MediaAccess.php
+++ b/MediaAccess.php
@@ -403,7 +403,11 @@ class MediaAccess
                 if ($imageType === 'image/jpeg') {
                     $image = imagecreatefromstring($content);
                     if ($image !== false) {
-                        $exif = exif_read_data($tempPath);
+                        try {
+                            $exif = @exif_read_data($tempPath);
+                        } catch (Exception $ex) {
+                            $exif = false;
+                        }
                         if ($exif !== false && !empty($exif['Orientation'])) {
                             switch ($exif['Orientation']) {
                                 case 3:

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -58,6 +58,8 @@ Ver.5.6 (in development)
 - Some functions are moved to INTER-Mediator-Navi, and refactored them.
 - Update FileMaker sample DB ("TestDB.fmp12" and "TestDB_clone.fmp12") to set the REST API / PHP API access privilege, 
   and so on.
+- Use @-operator before exif_read_data() in MediaAccess.php to avoid outputting a warning in an error log file in case
+  of using PHP 5.6.
 - [SECURITY FIX] The resetpassword.php in Auth_Support/PasswordReset folder had security issues.
   If you use the resetpassword.php file in your solution. we'd like to replace the fixed version.
 - [BUG FIX] IMLibContext class's getDataAtLastRecord method had a bug (wrong parameters for getValue).


### PR DESCRIPTION
Used @-operator before exif_read_data() in MediaAccess.php to avoid outputting a warning in an error log file in case of using PHP 5.6.

Related page: https://bugs.php.net/bug.php?id=72819