### PR TITLE
Update DB_FileMaker_FX.php to avoid outputting warnings in some rare cases

### DIFF
--- a/DB_FileMaker_FX.php
+++ b/DB_FileMaker_FX.php
@@ -834,7 +834,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
         }
         if (isset($context['global'])) {
             foreach ($context['global'] as $condition) {
-                if ($condition['db-operation'] == 'load' || $condition['db-operation'] == 'read') {
+                if (isset($condition['db-operation']) && in_array($condition['db-operation'], array('load', 'read'))) {
                     $this->fx->SetFMGlobal($condition['field'], $condition['value']);
                 }
             }
@@ -850,7 +850,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
         $queryString .= '&-max=' . $this->fx->groupSize . $skipRequest;
         if (isset($context['script'])) {
             foreach ($context['script'] as $condition) {
-                if ($condition['db-operation'] == 'load' || $condition['db-operation'] == 'read') {
+                if (isset($condition['db-operation']) && in_array($condition['db-operation'], array('load', 'read'))) {
                     $queryString .= $this->executeScriptsforLoading($context['script']);
                 }
             }
@@ -894,7 +894,7 @@ class DB_FileMaker_FX extends DB_AuthCommon implements DB_Access_Interface
         } else {
             $currentSearch = '';
             if (isset($context['script'])) {
-                if ($condition['db-operation'] == 'load' || $condition['db-operation'] == 'read') {
+                if (isset($condition['db-operation']) && in_array($condition['db-operation'], array('load', 'read'))) {
                     $currentSearch = $this->executeScriptsforLoading($context['script']);
                 }
             }


### PR DESCRIPTION
Updated DB_FileMaker_FX.php to avoid outputting warnings when executing FileMaker scripts in some rare cases.