### PR TITLE
Revert partly and output an error message when using deprecated global variables in INTER-Mediator.php

### DIFF
--- a/INTER-Mediator.php
+++ b/INTER-Mediator.php
@@ -47,7 +47,7 @@ $g_dbInstance = null;
 
 function IM_Entry($datasource, $options, $dbspecification, $debug = false)
 {
-//    global $g_dbInstance, $g_serverSideCall;
+    global $g_dbInstance, $g_serverSideCall;
 
     // check required PHP extensions
     $requiredFunctions = array(
@@ -78,6 +78,12 @@ function IM_Entry($datasource, $options, $dbspecification, $debug = false)
     if (isset($_GET['theme'])) {
         $themeManager = new Theme();
         $themeManager->processing();
+    } else if (isset($g_serverSideCall) && $g_serverSideCall) {
+        $dbInstance = new DB_Proxy();
+        $dbInstance->initialize($datasource, $options, $dbspecification, $debug);
+        $dbInstance->processingRequest("NON");
+        $g_dbInstance = $dbInstance;
+        error_log('Deprecated global variables $g_dbInstance, $g_serverSideCall in INTER-Mediator.php will be removed in Ver.6.0');
     } else if (!isset($_POST['access']) && isset($_GET['uploadprocess'])) {
         $fileUploader = new FileUploader();
         $fileUploader->processInfo();

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -79,6 +79,20 @@ Ver.5.7-dev (in development)
 - All functions have 'use strict';.
 - Update deploy.sh and recipe.rb etc. for the INTER-Mediator-Server virtual machine and CI.
 - Field names that contain ':' can be a variable of expression. It's for FileMaker.
+- [INFO] The following methods are deprecated. These methods will be removed in Ver.6.0.
+    INTERMediator_DBAdapter.server_access
+    INTERMediator_DBAdapter.db_query
+    INTERMediator_DBAdapter.db_queryWithAuth
+    INTERMediator_DBAdapter.db_update
+    INTERMediator_DBAdapter.db_updateWithAuth
+    INTERMediator_DBAdapter.db_delete
+    INTERMediator_DBAdapter.db_deleteWithAuth
+    INTERMediator_DBAdapter.db_createRecord
+    INTERMediator_DBAdapter.db_createRecordWithAuth
+    INTERMediator_DBAdapter.db_copy
+    INTERMediator_DBAdapter.db_copyWithAuth
+- [INFO] Deprecated global variables $g_dbInstance, $g_serverSideCall in INTER-Mediator.php will be removed
+  in Ver.6.0.
 - [BUG FIX] Fix to add multiple times for target node which has "#" started target description.
 - [BUG FIX] Replace the dataset property to set/get attribute methods for IE10.
 - [BUG FIX] Justify the next line handling in TEXTAREA tagged element for IE9.

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"version":"5.7-dev","releasedate":"2018-01-21"}
+{"version":"5.7-dev","releasedate":"2018-01-24"}


### PR DESCRIPTION
Please not to remove the deprecated global variables ($g_dbInstance and $g_serverSideCall) in INTER-Mediator.php in Ver.5.7.