### PR TITLE
Fix not to show the error message when the JavaScript component plugin hasn't "_im_setValue" method

### DIFF
--- a/INTER-Mediator-Element.js
+++ b/INTER-Mediator-Element.js
@@ -274,7 +274,9 @@ var IMLibElement = {
                 }
             } else { // Setting
                 if (INTERMediatorLib.isWidgetElement(element)) {
-                    element._im_setValue(curVal);
+                    if (element._im_setValue) {
+                        element._im_setValue(curVal);
+                    }
                 } else if (curTarget === 'innerHTML') { // Setting
                     if (INTERMediator.isIE && INTERMediator.ieVersion < 10) { // for IE
                         curVal = curVal.replace(/\r\n/g, '\r').replace(/\n/g, '\r').replace(/\r/g, '<br/>');
@@ -308,7 +310,9 @@ var IMLibElement = {
             }
         } else { // if the 'target' is not specified.
             if (INTERMediatorLib.isWidgetElement(element)) {
-                element._im_setValue(curVal);
+                if (element._im_setValue) {
+                    element._im_setValue(curVal);
+                }
             } else if (element.tagName === 'INPUT') {
                 typeAttr = element.getAttribute('type');
                 if (typeAttr === 'checkbox' || typeAttr === 'radio') { // set the value

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -128,6 +128,8 @@ Ver.5.7-RC3-dev (in development)
 - [BUG FIX] If a expression set to popup menu, the page generating process went infinite loop (bug on 99fbf43b).
 - [BUG FIX] Stabilized to detect smtp server info and refactored.
 - [BUG FIX] The method to change password for FileMaker Server had a bug.
+- [BUG FIX] Fix not to show the error message ("element._im_setValue is not a function - EXCEPTION-27") when
+  the JavaScript component plugin hasn't "_im_setValue" method.
 
 Ver.5.6.1 (September 16, 2017)
 - Fix loading the page of the Practice "search (using JavaScript)".

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"version":"5.7-RC3-dev","releasedate":"2018-03-21"}
+{"version":"5.7-RC3-dev","releasedate":"2018-03-22"}


### PR DESCRIPTION
Fixed not to show the error message ("element._im_setValue is not a function - EXCEPTION-27") when the JavaScript component plugin hasn't "_im_setValue" method.