### PR TITLE
Stable for PHP 7.2. On PHP 7.2, some methods showed warning messages.

### DIFF
--- a/src/php/DB/FileMaker_DataAPI.php
+++ b/src/php/DB/FileMaker_DataAPI.php
@@ -365,7 +365,7 @@ class FileMaker_DataAPI extends UseSharedObjects implements DBClass_Interface
 
                     $searchConditions[] = $this->setSearchConditionsForCompoundFound(
                         $condition['field'], $condition['value'], $condition['operator']);
-                    
+
                     if (isset($condition['operator']) && $condition['operator'] === 'neq') {
                         $neqConditions[] = TRUE;
                     } else {
@@ -563,7 +563,7 @@ class FileMaker_DataAPI extends UseSharedObjects implements DBClass_Interface
         $scriptResultPresort = NULL;
         $scriptResult = NULL;
         try {
-            if (count($conditions) === 1 && isset($conditions[0]['recordId'])) {
+            if ($conditions && count($conditions) === 1 && isset($conditions[0]['recordId'])) {
                 $recordId = str_replace('=', '', $conditions[0]['recordId']);
                 if (is_numeric($recordId)) {
                     $conditions[0]['recordId'] = $recordId;
@@ -574,7 +574,7 @@ class FileMaker_DataAPI extends UseSharedObjects implements DBClass_Interface
             }
 
             $this->notifyHandler->setQueriedEntity($layout);
-            $this->notifyHandler->setQueriedCondition("/fmi/rest/api/find/{$this->dbSettings->getDbSpecDatabase()}/{$layout}" . ($recordId ? "/{$recordId}" : ""));            
+            $this->notifyHandler->setQueriedCondition("/fmi/rest/api/find/{$this->dbSettings->getDbSpecDatabase()}/{$layout}" . ($recordId ? "/{$recordId}" : ""));
 
             if (!is_null($result)) {
                 $portalNames = $result->getPortalNames();
@@ -634,7 +634,7 @@ class FileMaker_DataAPI extends UseSharedObjects implements DBClass_Interface
                         )
                     );
                 }
-                
+
                 $relatedsetArray = array();
                 if (count($portalNames) >= 1) {
                     $relatedArray = array();
@@ -650,7 +650,7 @@ class FileMaker_DataAPI extends UseSharedObjects implements DBClass_Interface
                                     }
                                     if ($relatedFieldName !== 'recordId') {
                                         $relatedArray[$tableOccurrence][$recId] += array(
-                                            $relatedFieldName =>                                     
+                                            $relatedFieldName =>
                                                 $this->formatter->formatterFromDB(
                                                     "{$tableOccurrence}{$this->dbSettings->getSeparator()}{$relatedFieldName}",
                                                     $portalRecord->{$relatedFieldName}
@@ -678,7 +678,7 @@ class FileMaker_DataAPI extends UseSharedObjects implements DBClass_Interface
                     break;
                 }
             }
-            
+
 
             if ($scriptResultPrerequest !== NULL || $scriptResultPresort !== NULL || $scriptResult !== NULL) {
                 // Avoid multiple executing FileMaker script
@@ -697,7 +697,7 @@ class FileMaker_DataAPI extends UseSharedObjects implements DBClass_Interface
                     $this->mainTableTotalCount = intval($scriptResult);
                 }
             } else {
-                if (count($conditions) === 1 && isset($conditions[0]['recordId']) && is_numeric($recordId)) {
+                if ($conditions && count($conditions) === 1 && isset($conditions[0]['recordId']) && is_numeric($recordId)) {
                     $this->mainTableCount = 1;
                 } else {
                     $result = $this->fmData->{$layout}->query($conditions, NULL, 1, 100000000, NULL, $script);
@@ -728,7 +728,7 @@ class FileMaker_DataAPI extends UseSharedObjects implements DBClass_Interface
     {
         $returnArray = array();
         $tableName = $this->dbSettings->getEntityForRetrieve();
-        
+
         foreach ($resultData as $oneRecord) {
             $oneRecordArray = array();
 
@@ -755,7 +755,7 @@ class FileMaker_DataAPI extends UseSharedObjects implements DBClass_Interface
             }
             $returnArray[] = $oneRecordArray;
         }
-        
+
         return $returnArray;
     }
 

--- a/src/php/DB/Support/DB_Auth_Handler_FileMaker_DataAPI.php
+++ b/src/php/DB/Support/DB_Auth_Handler_FileMaker_DataAPI.php
@@ -12,8 +12,10 @@
  * @link          https://inter-mediator.com/
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace INTERMediator\DB\Support;
-use \Datetime;
+
+use Datetime;
 
 class DB_Auth_Handler_FileMaker_DataAPI extends DB_Auth_Common implements Auth_Interface_DB
 {
@@ -43,7 +45,8 @@ class DB_Auth_Handler_FileMaker_DataAPI extends DB_Auth_Common implements Auth_I
         $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential($this->dbClass->fmDataAuth->{$hashTable}->getDebugInfo()));
         $currentDT = new DateTime();
         $currentDTFormat = $currentDT->format('m/d/Y H:i:s');
-        if (get_class($result) === 'INTERMediator\\FileMakerServer\\RESTAPI\\Supporting\\FileMakerRelation') {
+        $className = is_object($result) ? get_class($result) : "NULL";
+        if ($className === 'INTERMediator\\FileMakerServer\\RESTAPI\\Supporting\\FileMakerRelation') {
             foreach ($result as $record) {
                 $recordId = $record->getRecordId();
                 $this->dbClass->$forAuth($hashTable, 1);
@@ -132,6 +135,7 @@ class DB_Auth_Handler_FileMaker_DataAPI extends DB_Auth_Common implements Auth_I
         }
         $this->dbClass->setupFMDataAPIforAuth($hashTable, 1);
         $conditions = array(array('user_id' => $uid, 'clienthost' => $clientId));
+        $result = NULL;
         try {
             $result = $this->dbClass->fmDataAuth->{$hashTable}->query($conditions);
             if (!isset($_SESSION['X-FM-Data-Access-Token'])) {
@@ -158,8 +162,9 @@ class DB_Auth_Handler_FileMaker_DataAPI extends DB_Auth_Common implements Auth_I
             return false;
         }
 
-        if (get_class($result) !== 'INTERMediator\\FileMakerServer\\RESTAPI\\Supporting\\FileMakerRelation') {
-            $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential(get_class($result) . ': ' . $this->dbClass->fmDataAuth->{$hashTable}->getDebugInfo()));
+        $className = is_object($result) ? get_class($result) : "NULL";
+        if ($className !== 'INTERMediator\\FileMakerServer\\RESTAPI\\Supporting\\FileMakerRelation') {
+            $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential($className . ': ' . $this->dbClass->fmDataAuth->{$hashTable}->getDebugInfo()));
             return false;
         }
         $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential($this->dbClass->fmDataAuth->{$hashTable}->getDebugInfo()));
@@ -184,8 +189,9 @@ class DB_Auth_Handler_FileMaker_DataAPI extends DB_Auth_Common implements Auth_I
             if (!isset($_SESSION['X-FM-Data-Access-Token'])) {
                 $_SESSION['X-FM-Data-Access-Token'] = $this->dbClass->fmDataAuth->getSessionToken();
             }
-            if (get_class($result) !== 'INTERMediator\\FileMakerServer\\RESTAPI\\Supporting\\FileMakerRelation') {
-                $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential(get_class($result) . ': ' . $this->dbClass->fmDataAuth->{$hashTable}->getDebugInfo()));
+            $className = is_object($result) ? get_class($result) : "NULL";
+            if ($className !== 'INTERMediator\\FileMakerServer\\RESTAPI\\Supporting\\FileMakerRelation') {
+                $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential($className . ': ' . $this->dbClass->fmDataAuth->{$hashTable}->getDebugInfo()));
                 return false;
             }
             $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential($this->dbClass->fmDataAuth->{$hashTable}->getDebugInfo()));
@@ -218,19 +224,21 @@ class DB_Auth_Handler_FileMaker_DataAPI extends DB_Auth_Common implements Auth_I
 
         $this->dbClass->setupFMDataAPIforDB($userTable, 1);
         $conditions = array(array('username' => str_replace('@', '\\@', $username)));
+        $result = NULL;
         try {
             $result = $this->dbClass->fmData->{$userTable}->query($conditions);
             if (!isset($_SESSION['X-FM-Data-Access-Token'])) {
                 $_SESSION['X-FM-Data-Access-Token'] = $this->dbClass->fmData->getSessionToken();
             }
         } catch (\Exception $e) {
-            $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential(get_class($result) . ': ' . $this->dbClass->fmData->{$userTable}->getDebugInfo()));
+            $className = is_object($result) ? get_class($result) : "NULL";
+            $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential($className . ': ' . $this->dbClass->fmData->{$userTable}->getDebugInfo()));
             return false;
         }
 
         $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential($this->dbClass->fmData->{$userTable}->getDebugInfo()));
         if ((get_class($result) !== 'INTERMediator\\FileMakerServer\\RESTAPI\\Supporting\\FileMakerRelation' ||
-            $result->count() < 1) && $this->dbSettings->getEmailAsAccount()) {
+                $result->count() < 1) && $this->dbSettings->getEmailAsAccount()) {
             $this->dbClass->setupFMDataAPIforDB($userTable, 1);
             $conditions = array(array('email' => str_replace('@', '\\@', $username)));
             try {
@@ -332,13 +340,15 @@ class DB_Auth_Handler_FileMaker_DataAPI extends DB_Auth_Common implements Auth_I
 
         $this->dbClass->setupFMDataAPIforDB_Alt($userTable, 1);
         $conditions = array(array('username' => str_replace('@', '\\@', $username)));
+        $result = NULL;
         try {
             $result = $this->dbClass->fmDataAlt->{$userTable}->query($conditions);
             if (!isset($_SESSION['X-FM-Data-Access-Token'])) {
                 $_SESSION['X-FM-Data-Access-Token'] = $this->dbClass->fmDataAlt->getSessionToken();
             }
         } catch (\Exception $e) {
-            $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential(get_class($result) . ': ' . $this->dbClass->fmDataAlt->{$userTable}->getDebugInfo()));
+            $className = is_object($result) ? get_class($result) : "NULL";
+            $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential($className . ': ' . $this->dbClass->fmDataAlt->{$userTable}->getDebugInfo()));
             return false;
         }
 
@@ -434,6 +444,7 @@ class DB_Auth_Handler_FileMaker_DataAPI extends DB_Auth_Common implements Auth_I
 
         $this->dbClass->setupFMDataAPIforDB_Alt($userTable, 55555);
         $conditions = array(array('username' => str_replace("@", "\\@", $username)), array('email' => str_replace("@", "\\@", $username)));
+        $result = NULL;
         try {
             $result = $this->dbClass->fmDataAlt->{$userTable}->query($conditions);
             if (!isset($_SESSION['X-FM-Data-Access-Token'])) {
@@ -450,7 +461,8 @@ class DB_Auth_Handler_FileMaker_DataAPI extends DB_Auth_Common implements Auth_I
                 }
             }
         } catch (\Exception $e) {
-            $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential(get_class($result) . ': ' . $this->dbClass->fmDataAlt->{$userTable}->getDebugInfo()));
+            $className = is_object($result) ? get_class($result) : "NULL";
+            $this->logger->setDebugMessage($this->dbClass->stringWithoutCredential($className . ': ' . $this->dbClass->fmDataAlt->{$userTable}->getDebugInfo()));
             return false;
         }
         return $usernameCandidate;


### PR DESCRIPTION
get_class method requires real object for its parameter. If it's null or no other object, the method shows warning message. I checked on PHP 7.2 from Homebrew.