### PR TITLE
Modify script of GitLab CI Test.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ before_script:
 test:
   script:
     - docker run -e "container=docker" -d --name alpine alpine:latest /sbin/init
-    - docker exec -e DISPLAY=:99.0 -i alpine sh -c "apk add --no-cache sudo curl php7 php7-xmlwriter php7-tokenizer ruby ruby-json ruby-io-console ruby-etc git && git clone https://github.com/INTER-Mediator/INTER-Mediator && cd INTER-Mediator && git checkout master && gem install itamae --no-doc && itamae local dist-docs/vm-for-trial/recipe.rb; dist-docs/installfiles.sh -2"
+    - docker exec -e DISPLAY=:99.0 -i alpine sh -c "apk add --no-cache sudo curl php7 php7-json php7-phar php7-iconv php7-openssl php7-dom php7-mbstring php7-pdo php7-bcmath php7-curl php7-xml php7-simplexml php7-ctype php7-xmlwriter php7-tokenizer ruby ruby-json ruby-io-console ruby-etc git && git clone https://github.com/INTER-Mediator/INTER-Mediator && cd INTER-Mediator && git checkout master && gem install itamae --no-doc && itamae local dist-docs/vm-for-trial/recipe.rb; dist-docs/installfiles.sh -2"
     - docker exec -e DISPLAY=:99.0 -i alpine sh -c "php -v; curl -sS https://getcomposer.org/installer | php; mv composer.phar /usr/local/bin/composer; chmod +x /usr/local/bin/composer; cd /INTER-Mediator/; /usr/local/bin/composer require --dev phpunit/phpunit ^8; /usr/local/bin/composer install; ./vendor/bin/phpunit --bootstrap /INTER-Mediator/vendor/autoload.php --configuration /INTER-Mediator/spec/INTER-Mediator-UnitTest/phpunit.xml /INTER-Mediator/spec/INTER-Mediator-UnitTest/INTERMediator_AllTests.php"
     - docker exec -e DISPLAY=:99.0 -i alpine sh -c "cd /INTER-Mediator/spec && ../node_modules/.bin/jest"
     - docker stop alpine


### PR DESCRIPTION
The GitLab CI fails on the test phase. Below messages appear.

 Make sure that you fix the issues listed below and run this script again:
 The json extension is missing.
 Install it or recompile php without --disable-json
 The phar extension is missing.
 Install it or recompile php without --disable-phar
 The iconv OR mbstring extension is required and both are missing.
 Install either of them or recompile php without --disable-iconv
 The openssl extension is missing, which means that secure HTTPS transfers are impossible.
 If possible you should enable it or recompile php with --with-openssl