### PR TITLE
Fix GenerateJSCode.php to consider when "INTER-Mediator-Support" directory doesn't exist

### DIFF
--- a/GenerateJSCode.php
+++ b/GenerateJSCode.php
@@ -106,14 +106,16 @@ class GenerateJSCode
          */
         $relativeToDefFile = '';
         $editorPath = realpath(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'INTER-Mediator-Support');
-        $defFilePath = realpath($_SERVER['DOCUMENT_ROOT'] . $_SERVER['SCRIPT_NAME']);
-        while (strpos($defFilePath, $editorPath) !== 0 && strlen($editorPath) > 1) {
-            $editorPath = dirname($editorPath);
-            $relativeToDefFile .= '..' . DIRECTORY_SEPARATOR;
+        if ($editorPath !== false) {  // In case of core only build.
+            $defFilePath = realpath($_SERVER['DOCUMENT_ROOT'] . $_SERVER['SCRIPT_NAME']);
+            while (strpos($defFilePath, $editorPath) !== 0 && strlen($editorPath) > 1) {
+                $editorPath = dirname($editorPath);
+                $relativeToDefFile .= '..' . DIRECTORY_SEPARATOR;
+            }
+            $relativeToDefFile .= substr($defFilePath, strlen($editorPath) + 1);
+            $editorPath = dirname(__FILE__) . DIRECTORY_SEPARATOR
+                . 'INTER-Mediator-Support' . DIRECTORY_SEPARATOR . 'defedit.html';
         }
-        $relativeToDefFile .= substr($defFilePath, strlen($editorPath) + 1);
-        $editorPath = dirname(__FILE__) . DIRECTORY_SEPARATOR
-            . 'INTER-Mediator-Support' . DIRECTORY_SEPARATOR . 'defedit.html';
         if (file_exists($editorPath)) {
             $relativeToEditor = substr($editorPath, strlen($_SERVER['DOCUMENT_ROOT']));
             $this->generateAssignJS("INTERMediatorOnPage.getEditorPath",
@@ -133,7 +135,9 @@ class GenerateJSCode
         if ($dbClassName !== 'DB_DefEditor' && $dbClassName !== 'DB_PageEditor') {
             require_once("{$dbClassName}.php");
         } else {
-            require_once(dirname(__FILE__) . "/INTER-Mediator-Support/{$dbClassName}.php");
+            if (file_exists(dirname(__FILE__) . "/INTER-Mediator-Support/{$dbClassName}.php")) {
+                require_once(dirname(__FILE__) . "/INTER-Mediator-Support/{$dbClassName}.php");
+            }
         }
         $dbInstance = new $dbClassName();
         $dbInstance->setupHandlers($dbDSN);

--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -14,6 +14,7 @@ Ver.5.13-dev (in development)
 - Our CI operations moved to GitHub Actions from Travis CI.
 - [BUG FIX] If nodes bond to the local context exist in enclosure/repeater (ex. within table tag), Some error (1046)
   rose up. So far the error doesn't rise, but these nodes should exist out side of enclosure/repeater. (Thanks to Mr. Hayashi)
+- [BUG FIX] Fix GenerateJSCode.php to consider when "INTER-Mediator-Support" directory doesn't exist (Thanks to Tomomitsu Baba).
 
 Ver.5.12 (May 29, 2021)
 - Support PHP 8.0.

--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"version":"5.13-dev","releasedate":"2021-06-28"}
+{"version":"5.13-dev","releasedate":"2021-08-14"}


### PR DESCRIPTION
Backport to 5.x branch.
Related commit: 1f0b37f4b29a6321b0f89d13ce11d2a86649a033