### PR TITLE
Modify change_log.txt (#1844)

### DIFF
--- a/dist-docs/change_log.txt
+++ b/dist-docs/change_log.txt
@@ -30,7 +30,8 @@ Ver.12 (In Development)
 - [BUG FIX] The INPUT[type=datetime-local] elements reported someone edit your modified data, but it was new record data
   after updateing is not adjusted to UTC correctly. Also INTERMediatorLib.dateTimeStringISO and some method returns
   browser local date and time.
-- [BUG FIX] Fix an error when using PHP 8.1.25 or later / PHP 8.2.12 or later / PHP 8.3.0 or later and $appLocale is undefined in params.php.
+- [BUG FIX] Fix an error when using PHP 8.3.0 or later / PHP 8.1.25  / PHP 8.2.12 and $appLocale is undefined in
+  params.php.
 
 Ver.11 (July 27, 2023)
 - Generic exporting class prepared as DB\Export.php.


### PR DESCRIPTION
I have updated change_log.txt because the changes in PHP 8.1.26 and PHP 8.2.13 included the statement "Removed the BC break on IntlDateFormatter::construct which threw an exception with an invalid locale".

Related links:
- https://www.php.net/ChangeLog-8.php#8.1.26
- https://www.php.net/ChangeLog-8.php#8.2.13
- #1844