### PR TITLE
Remove errors("Variable $serviceServerHost on left side of ?? always exists and is not nullable.") detected by PHPStan

### DIFF
--- a/spec/INTER-Mediator-UnitTest/Core/GenerateJSCode_Test.php
+++ b/spec/INTER-Mediator-UnitTest/Core/GenerateJSCode_Test.php
@@ -14,6 +14,7 @@ class GenerateJSCode_Test extends TestCase
 
     protected function setUp(): void
     {
+        $_SERVER = [];
         $_SERVER['SCRIPT_NAME'] = __FILE__;
         $this->generater = new GenerateJSCode();
     }
@@ -36,6 +37,57 @@ class GenerateJSCode_Test extends TestCase
     {
         $this->expectOutputString('INTERMediatorLog.setErrorMessage("PHP extension \"mbstring\" is required for running INTER-Mediator. ");');
         $this->generater->generateErrorMessageJS('PHP extension "mbstring" is required for running INTER-Mediator.' . "\n");
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    function test_generateInitialJSCode()
+    {
+        $_SERVER = [];
+        $_SERVER['HTTP_REFERER'] = '';
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $_SERVER['DOCUMENT_ROOT'] = '/tmp';
+        $_SERVER['SCRIPT_NAME'] = __FILE__;
+        $_SERVER['REMOTE_ADDR'] = '';
+        $this->expectOutputRegex('/INTERMediatorLog.debugMode=false;/');
+        $this->expectOutputRegex('/INTERMediatorOnPage.serviceServerURL="ws:\/\/localhost:/');
+        $this->generater->generateInitialJSCode([], [], [], 0);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    function test_generateInitialJSCode2()
+    {
+        $_SERVER = [];
+        $_SERVER['HTTP_REFERER'] = '';
+        $_SERVER['HTTP_HOST'] = 'localhost:80';
+        $_SERVER['DOCUMENT_ROOT'] = '/tmp';
+        $_SERVER['SCRIPT_NAME'] = __FILE__;
+        $_SERVER['REMOTE_ADDR'] = '';
+        $this->expectOutputRegex('/INTERMediatorLog.debugMode=false;/');
+        $this->expectOutputRegex('/INTERMediatorOnPage.serviceServerURL="ws:\/\/localhost:/');
+        $this->generater->generateInitialJSCode([], [], [], 0);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    function test_generateInitialJSCode3()
+    {
+        $_SERVER = [];
+        $_SERVER['HTTP_REFERER'] = '';
+        //$_SERVER['HTTP_HOST'] = '';
+        $_SERVER['DOCUMENT_ROOT'] = '/tmp';
+        $_SERVER['SCRIPT_NAME'] = __FILE__;
+        $_SERVER['REMOTE_ADDR'] = '';
+        $this->expectOutputRegex('/INTERMediatorLog.debugMode=false;/');
+        $this->expectOutputRegex('/INTERMediatorOnPage.serviceServerURL="ws:\/\/localhost:/');
+        $this->generater->generateInitialJSCode([], [], [], 0);
     }
 
     /**

--- a/spec/INTER-Mediator-UnitTest/Core/GenerateJSCode_Test.php
+++ b/spec/INTER-Mediator-UnitTest/Core/GenerateJSCode_Test.php
@@ -14,7 +14,6 @@ class GenerateJSCode_Test extends TestCase
 
     protected function setUp(): void
     {
-        $_SERVER = [];
         $_SERVER['SCRIPT_NAME'] = __FILE__;
         $this->generater = new GenerateJSCode();
     }
@@ -45,15 +44,11 @@ class GenerateJSCode_Test extends TestCase
      */
     function test_generateInitialJSCode()
     {
-        $_SERVER = [];
-        $_SERVER['HTTP_REFERER'] = '';
         $_SERVER['HTTP_HOST'] = 'localhost';
-        $_SERVER['DOCUMENT_ROOT'] = '/tmp';
-        $_SERVER['SCRIPT_NAME'] = __FILE__;
+        $_SERVER['HTTP_REFERER'] = '';
         $_SERVER['REMOTE_ADDR'] = '';
-        $this->expectOutputRegex('/INTERMediatorLog.debugMode=false;/');
         $this->expectOutputRegex('/INTERMediatorOnPage.serviceServerURL="ws:\/\/localhost:/');
-        $this->generater->generateInitialJSCode([], [], [], 0);
+        $this->generater->generateInitialJSCode([], [], ['db-class' => 'PDO'], false);
     }
 
     /**
@@ -62,15 +57,11 @@ class GenerateJSCode_Test extends TestCase
      */
     function test_generateInitialJSCode2()
     {
-        $_SERVER = [];
-        $_SERVER['HTTP_REFERER'] = '';
         $_SERVER['HTTP_HOST'] = 'localhost:80';
-        $_SERVER['DOCUMENT_ROOT'] = '/tmp';
-        $_SERVER['SCRIPT_NAME'] = __FILE__;
+        $_SERVER['HTTP_REFERER'] = '';
         $_SERVER['REMOTE_ADDR'] = '';
-        $this->expectOutputRegex('/INTERMediatorLog.debugMode=false;/');
         $this->expectOutputRegex('/INTERMediatorOnPage.serviceServerURL="ws:\/\/localhost:/');
-        $this->generater->generateInitialJSCode([], [], [], 0);
+        $this->generater->generateInitialJSCode([], [], ['db-class' => 'PDO'], false);
     }
 
     /**
@@ -79,15 +70,11 @@ class GenerateJSCode_Test extends TestCase
      */
     function test_generateInitialJSCode3()
     {
-        $_SERVER = [];
-        $_SERVER['HTTP_REFERER'] = '';
         //$_SERVER['HTTP_HOST'] = '';
-        $_SERVER['DOCUMENT_ROOT'] = '/tmp';
-        $_SERVER['SCRIPT_NAME'] = __FILE__;
+        $_SERVER['HTTP_REFERER'] = '';
         $_SERVER['REMOTE_ADDR'] = '';
-        $this->expectOutputRegex('/INTERMediatorLog.debugMode=false;/');
         $this->expectOutputRegex('/INTERMediatorOnPage.serviceServerURL="ws:\/\/localhost:/');
-        $this->generater->generateInitialJSCode([], [], [], 0);
+        $this->generater->generateInitialJSCode([], [], ['db-class' => 'PDO'], false);
     }
 
     /**

--- a/src/php/DB/FileMaker_DataAPI.php
+++ b/src/php/DB/FileMaker_DataAPI.php
@@ -559,7 +559,7 @@ class FileMaker_DataAPI extends DBClass
                         $searchConditions[] = $this->setSearchConditionsForCompoundFound(
                             $foreignField, $formattedValue, $foreignOperator);
 
-                        if (isset($foreignOperator) && $foreignOperator === 'neq') {
+                        if ($foreignOperator === 'neq') {
                             $neqConditions[] = TRUE;
                         } else {
                             $neqConditions[] = FALSE;

--- a/src/php/DB/FileMaker_FX.php
+++ b/src/php/DB/FileMaker_FX.php
@@ -610,7 +610,7 @@ class FileMaker_FX extends DBClass
 
                             $queryValues[] = 'q' . $qNum;
                             $qNum++;
-                            if (isset($foreignOperator) && $foreignOperator === 'neq') {
+                            if ($foreignOperator === 'neq') {
                                 $neqConditions[] = TRUE;
                             } else {
                                 $neqConditions[] = FALSE;

--- a/src/php/GenerateJSCode.php
+++ b/src/php/GenerateJSCode.php
@@ -115,8 +115,14 @@ class GenerateJSCode
         $prohibitDebugMode = Params::getParameterValue('prohibitDebugMode', false);
         $resetPage = $options['authentication']['reset-page'] ?? $resetPage ?? null;
         $enrollPage = $options['authentication']['enroll-page'] ?? $enrollPage ?? null;
-        $serviceServerHost = $serviceServerHost ?? $_SERVER['SERVER_ADDR'] ?? false;
-        $serviceServerHost = $serviceServerHost ?? parse_url($_SERVER['HTTP_HOST'], PHP_URL_HOST) ?? false;
+        $serviceServerHost = $serviceServerHost ?? $_SERVER['SERVER_ADDR'] ?? null;
+        if (isset($_SERVER['HTTP_HOST']) && !empty($_SERVER['HTTP_HOST'])) {
+            if (strpos($_SERVER['HTTP_HOST'], ':') === false) {
+                $serviceServerHost = $serviceServerHost ?? $_SERVER['HTTP_HOST'] ?? null;
+            } else {
+                $serviceServerHost = $serviceServerHost ?? parse_url($_SERVER['HTTP_HOST'], PHP_URL_HOST) ?? null;
+            }
+        }
         $serviceServerHost = $serviceServerHost ?? 'localhost';
         $passwordHash = ($passwordHash === '2m') ? 1.5 : floatval($passwordHash);
         $isSAML = $options['authentication']['is-saml'] ?? $isSAML ?? false;


### PR DESCRIPTION
Updated GenerateJSCode.php and GenerateJSCode_Test.php to also consider whether the HTTP_HOST header value contains ":" and port number or not.