### PR TITLE
Update package.json not to upgrading to TinyMCE 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "npm-platform-dependencies": "*",
         "socket.io": ">=3.1.0",
         "socket.io-client": ">=3.1.0",
-        "tinymce": ">=6.0.0"
+        "tinymce": "^6.8.3"
       },
       "devDependencies": {
         "jest": "*",
@@ -2304,9 +2304,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.754",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.754.tgz",
-      "integrity": "sha512-7Kr5jUdns5rL/M9wFFmMZAgFDuL2YOnanFH4OI4iFzUqyh3XOL7nAGbSlSMZdzKMIyyTpNSbqZsWG9odwLeKvA==",
+      "version": "1.4.756",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.756.tgz",
+      "integrity": "sha512-RJKZ9+vEBMeiPAvKNWyZjuYyUqMndcP1f335oHqn3BEQbs2NFtVrnK5+6Xg5wSM9TknNNpWghGDUCKGYF+xWXw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3449,11 +3449,6 @@
       "dependencies": {
         "tinymce": "^6.3.1"
       }
-    },
-    "node_modules/inter-mediator-plugin-tinymce/node_modules/tinymce": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.3.tgz",
-      "integrity": "sha512-3fCHKAeqT+xNwBVESf6iDbDV0VNwZNmfrkx9c/6Gz5iB8piMfaO6s7FvoiTrj1hf1gVbfyLTnz1DooI6DhgINQ=="
     },
     "node_modules/inter-mediator-queue": {
       "version": "1.0.9",
@@ -6314,9 +6309,9 @@
       }
     },
     "node_modules/tinymce": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-7.0.1.tgz",
-      "integrity": "sha512-0a7DJnhniBx2psRuKcVQ9g4hujN6PAR4fPS0NSF1T1luH1RBDZVVEn2pGND6Ly+AW1lUm/cHOHjsasqBelMhbw=="
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.3.tgz",
+      "integrity": "sha512-3fCHKAeqT+xNwBVESf6iDbDV0VNwZNmfrkx9c/6Gz5iB8piMfaO6s7FvoiTrj1hf1gVbfyLTnz1DooI6DhgINQ=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -6593,9 +6588,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.14.tgz",
-      "integrity": "sha512-JixKH8GR2pWYshIPUg/NujK3JO7JiqEEUiNArE86NQyrgUuZeTlZQN3xuS/yiV5Kb48ev9K6RqNkaJjXsdg7Jw==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.15.tgz",
+      "integrity": "sha512-K9HWH62x3/EalU1U6sjSZiylm9C8tgq2mSvshZpqc7QE69RaA2qjhkW2HlNA0tFpEbtyFz7HTqbSdN4MSwUodA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "npm-platform-dependencies": "*",
     "socket.io": ">=3.1.0",
     "socket.io-client": ">=3.1.0",
-    "tinymce": ">=6.0.0"
+    "tinymce": "^6.8.3"
   },
   "win32Dependencies": {
     "forever-win": "*"


### PR DESCRIPTION
Since the license of TinyMCE had been changed to GPL v2 or later, we would like to use TinyMCE 6 for a while and see how it goes.
https://www.tiny.cloud/docs/tinymce/latest/7.0-release-notes/