### PR TITLE
Add setup-pnpm action to integrate Takumi Guard into the CI E2E testing workflows

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,13 @@
+name: setup-pnpm
+description: Setup pnpm and Takumi Guard
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      with:
+        version: 10.33.0
+
+    - name: Setup Takumi Guard
+      uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1

--- a/.github/keep/e2e-test-firefox-form.yml
+++ b/.github/keep/e2e-test-firefox-form.yml
@@ -39,7 +39,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install PHP
         uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2.35.5
         with:
@@ -97,10 +97,8 @@ jobs:
       - name: Setup Firefox
         uses: browser-actions/setup-firefox@latest
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 10.17
+      - name: Install pnpm and setup Takumi Guard
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup WebdriverIO
         run: cd spec/run; pnpm config list; pnpm install --frozen-lockfile

--- a/.github/workflows/e2e-test-chrome-auth.yml
+++ b/.github/workflows/e2e-test-chrome-auth.yml
@@ -38,7 +38,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install PHP
         uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2.35.5
         with:
@@ -105,10 +105,8 @@ jobs:
           chrome-version: 126
           install-chromedriver: true
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 10.17
+      - name: Install pnpm and setup Takumi Guard
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup WebdriverIO
         run: cd spec/run; pnpm config list; pnpm install --frozen-lockfile

--- a/.github/workflows/e2e-test-chrome-editing.yml
+++ b/.github/workflows/e2e-test-chrome-editing.yml
@@ -38,7 +38,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install PHP
         uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2.35.5
         with:
@@ -105,10 +105,8 @@ jobs:
           chrome-version: 126
           install-chromedriver: true
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 10.17
+      - name: Install pnpm and setup Takumi Guard
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup WebdriverIO
         run: cd spec/run; pnpm config list; pnpm install --frozen-lockfile

--- a/.github/workflows/e2e-test-chrome-form.yml
+++ b/.github/workflows/e2e-test-chrome-form.yml
@@ -38,7 +38,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install PHP
         uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2.35.5
         with:
@@ -105,10 +105,8 @@ jobs:
           chrome-version: 126
           install-chromedriver: true
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 10.17
+      - name: Install pnpm and setup Takumi Guard
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup WebdriverIO
         run: cd spec/run; pnpm config list; pnpm install --frozen-lockfile

--- a/.github/workflows/e2e-test-firefox-auth.yml
+++ b/.github/workflows/e2e-test-firefox-auth.yml
@@ -39,7 +39,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install PHP
         uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2.35.5
         with:
@@ -103,10 +103,8 @@ jobs:
       - name: Setup Firefox
         uses: browser-actions/setup-firefox@latest
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 10.17
+      - name: Install pnpm and setup Takumi Guard
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup WebdriverIO
         run: cd spec/run; pnpm config list; pnpm install --frozen-lockfile

--- a/spec/run/.npmrc
+++ b/spec/run/.npmrc
@@ -1,0 +1,1 @@
+registry=https://npm.flatt.tech/


### PR DESCRIPTION
ref: https://shisho.dev/docs/ja/t/guard/quickstart/npm#setup-ci