### PR TITLE
Add job-level permissions to container-build workflow to fix GHCR push failure

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -14,6 +14,9 @@ jobs:
   publish:
     name: Publish Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The publish job was missing explicit permissions, causing "denied: installation not allowed to Write organization package" when pushing to GHCR.